### PR TITLE
feat(core): add env loading, encryption, CSRF/CORS/rate-limit middleware

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+APP_KEY=
+APP_ENV=development
+APP_DEBUG=true
+
+DB_HOST=127.0.0.1
+DB_PORT=3306
+DB_NAME=myapp
+DB_USER=root
+DB_PASS=
+
+CACHE_DRIVER=file
+
+MAIL_DRIVER=smtp
+MAIL_HOST=localhost
+MAIL_PORT=1025

--- a/app/config/auth.php
+++ b/app/config/auth.php
@@ -8,7 +8,7 @@ $config['auth'] = [
         ],
         'jwt' => [
             'provider' => 'users',
-            'secret' => 'sdf-jwt-secret-change-me',
+            'secret' => env('JWT_SECRET', ''),
             'ttl' => 3600,
             'refresh_ttl' => 604800,
             'algo' => 'HS256',

--- a/app/config/auth.php
+++ b/app/config/auth.php
@@ -1,0 +1,22 @@
+<?php
+
+$config['auth'] = [
+    'default' => 'session',
+    'guards' => [
+        'session' => [
+            'provider' => 'users',
+        ],
+        'jwt' => [
+            'provider' => 'users',
+            'secret' => 'sdf-jwt-secret-change-me',
+            'ttl' => 3600,
+            'refresh_ttl' => 604800,
+            'algo' => 'HS256',
+        ],
+    ],
+    'providers' => [
+        'users' => [
+            'model' => \App\Models\User::class,
+        ],
+    ],
+];

--- a/app/config/cors.php
+++ b/app/config/cors.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * CORS Configuration
+ *
+ * @var array $config
+ */
+$config['cors'] = [
+    'allowed_origins' => ['*'],
+    'allowed_origins_patterns' => [],
+    'allowed_methods' => ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+    'allowed_headers' => ['Content-Type', 'Authorization', 'X-Requested-With', 'X-CSRF-TOKEN'],
+    'exposed_headers' => [],
+    'max_age' => 86400,
+    'allow_credentials' => false,
+];

--- a/app/config/encryption.php
+++ b/app/config/encryption.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * Encryption Configuration
+ *
+ * @var array $config
+ */
+$config['encryption'] = [
+    // AES-256-CBC key (base64-encoded, 32 bytes when decoded)
+    // Generate: php -r "echo base64_encode(openssl_random_pseudo_bytes(32));"
+    'key' => getenv('APP_KEY') ?: '',
+
+    // Cipher method (openssl_get_cipher_methods() for all)
+    'cipher' => 'AES-256-CBC',
+];

--- a/app/views/home.php
+++ b/app/views/home.php
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <meta name="description" content="SDF Framework - A fast, modern PHP framework by devsimsek.">
-  <title>{{ $app_title ?? "SDF" }} — v{{ $app_version ?? SDF_VERSION }}</title>
+  <title>{{ $app_title ?? "SDF" }} - v{{ $app_version ?? SDF_VERSION }}</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
   <style>

--- a/app/views/home.php
+++ b/app/views/home.php
@@ -258,19 +258,19 @@
 
     <div class="bench-grid">
       <div class="bench-item">
-        <div class="bench-value">~57%</div>
-        <div class="bench-label">Faster avg render</div>
-        <div class="bench-sub">0.000157ms vs 0.000363ms</div>
+        <div class="bench-value">10,046</div>
+        <div class="bench-label">Req/sec</div>
+        <div class="bench-sub">FrankenPHP php-server</div>
       </div>
       <div class="bench-item">
-        <div class="bench-value">0.0001ms</div>
-        <div class="bench-label">Min response time</div>
-        <div class="bench-sub">down from 0.0002ms</div>
+        <div class="bench-value">1.46ms</div>
+        <div class="bench-label">Avg latency</div>
+        <div class="bench-sub">σ 5.08ms variance</div>
       </div>
       <div class="bench-item">
-        <div class="bench-value">61%</div>
-        <div class="bench-label">Less variance</div>
-        <div class="bench-sub">σ 0.000056ms vs 0.000143ms</div>
+        <div class="bench-value">543MB/s</div>
+        <div class="bench-label">Transfer rate</div>
+        <div class="bench-sub">full stack w/ Fuse view</div>
       </div>
     </div>
 

--- a/composer.json
+++ b/composer.json
@@ -4,11 +4,11 @@
     "type": "project",
     "require": {
         "php": ">=8.0",
-        "zircote/swagger-php": "^4.0",
         "ext-pdo": "*",
         "psr/http-message": "^2.0"
     },
     "require-dev": {
+        "zircote/swagger-php": "^4.0",
         "phpunit/phpunit": "^10.0",
         "phpstan/phpstan": "^1.10",
         "friendsofphp/php-cs-fixer": "^3.0"

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
     "require": {
         "php": ">=8.0",
         "zircote/swagger-php": "^4.0",
-        "ext-pdo": "*"
+        "ext-pdo": "*",
+        "psr/http-message": "^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.0",

--- a/sdf/__init.php
+++ b/sdf/__init.php
@@ -133,8 +133,8 @@ $router = Core::coreLoadClass("Router");
 
 // Register Swagger routes if the Swagger controller file exists
 if (class_exists(\SDF\Swagger\SwaggerController::class) && SDF_ENV === "development") {
-    $router::add('/api/openapi.json', 'Swagger/SwaggerController/spec', 'GET');
-    $router::add('/api/docs', 'Swagger/SwaggerController/docs', 'GET');
+    $router::add('/api/openapi.json', '\SDF\Swagger\SwaggerController@spec', 'GET');
+    $router::add('/api/docs', '\SDF\Swagger\SwaggerController@docs', 'GET');
 }
 
 $router::pathNotFound(SDF_EH_404);

--- a/sdf/__init.php
+++ b/sdf/__init.php
@@ -95,31 +95,26 @@ require SDF_DIR . "constants.php";
 
 // Load Composer autoloader (PSR-4 support for SDF\ namespace)
 $composerAutoload = SDF_DIR . '../vendor/autoload.php';
-if (file_exists($composerAutoload)) {
+if (is_file($composerAutoload)) {
     require_once $composerAutoload;
 }
 
 // lets require our core, benchmark and router files.
 require SDF_DIR . "core/Core.php";
-$bm = Core::coreLoadClass("Benchmark");
-// And Here We Start Benchmarking...
-$bm->mark("__sdf__init__start__");
+Core::coreLoadConfigurations();
 
 // Initialize Logger early so we can write debug marks
 require_once SDF_DIR . "core/Logger.php";
-Core::coreLoadConfigurations();
-// Use configuration if present (do not crash if not)
 $loggerConfig = Core::coreGetConfig("logger") ?: [];
 $logger = SDF\Logger::getInstance($loggerConfig);
 
-// Initialize Cache facade
-require_once SDF_DIR . "core/Cache/CacheDriver.php";
-require_once SDF_DIR . "core/Cache/Cache.php";
-require_once SDF_DIR . "core/Cache/FileDriver.php";
-require_once SDF_DIR . "core/Cache/RedisDriver.php";
-require_once SDF_DIR . "core/Cache/MemcachedDriver.php";
-$cacheDriver = Core::coreGetConfig("cache", "driver") ?: "file";
-SDF\Logger::log(Level::DEBUG, "Cache facade initialized", ["driver" => $cacheDriver]);
+if (SDF_BENCHMARK) {
+    $bm = Core::coreLoadClass("Benchmark");
+    $bm->mark("__sdf__init__start__");
+}
+
+// Initialize Cache facade (load required files, driver loaded on demand)
+require_once SDF_DIR . "core/Cache/__init.php";
 
 // sdf-15: better error handling and managed exceptions
 require_once SDF_DIR . "core/Exceptions.php"; // https://github.com/devsimsek/project-sdf/pull/12#discussion_r3299746185
@@ -130,115 +125,10 @@ require SDF_APP . "handlers/errors.php";
 // And Router...
 $router = Core::coreLoadClass("Router");
 
-// Initialize Spark ORM
-$dbConfig = Core::coreGetConfig("database");
-try {
-    if ($dbConfig) {
-        SDF\Logger::log(Level::DEBUG, "Initializing database connection", [
-            "driver" => $dbConfig["driver"] ?? null,
-        ]);
-        // perf: use a static variable to hold dsn
-        static $dsn = null;
-        switch ($dbConfig["driver"]) {
-            case "mysql":
-                if ($dsn === null) {
-                    $dsn = "mysql:host=" .
-                      $dbConfig["host"] .
-                      ";dbname=" .
-                      $dbConfig["name"] .
-                      ";port=" .
-                      ($dbConfig["port"] ?? "3306") .
-                      ";charset=" .
-                      ($dbConfig["charset"] ?? "utf8mb4");
-                }
-                \SDF\Spark::connect(
-                    $dsn,
-                    $dbConfig["user"],
-                    $dbConfig["password"],
-                );
-                break;
-            case "psql":
-            case "pgsql":
-            case "postgres":
-                if ($dsn === null) {
-                    $dsn = "pgsql:host=" .
-                      $dbConfig["host"] .
-                      ";dbname=" .
-                      $dbConfig["name"] .
-                      ";port=" .
-                      ($dbConfig["port"] ?? "5432");
-                }
-
-                \SDF\Spark::connect(
-                    $dsn,
-                    $dbConfig["user"],
-                    $dbConfig["password"],
-                );
-                break;
-            case "sqlite":
-                $sqlitePath = $dbConfig["path"] ?? ($dbConfig["dsn"] ?? null);
-                if ($sqlitePath === null) {
-                    throw new \Exception(
-                        "SQLite configuration missing path/dsn",
-                    );
-                }
-                // If it already looks like a DSN (contains ':'), use as-is; otherwise prepend sqlite:
-                if (str_contains($sqlitePath, ":")) {
-                    \SDF\Spark::connect($sqlitePath);
-                } else {
-                    \SDF\Spark::connect("sqlite:" . $sqlitePath);
-                }
-                break;
-            case "sqlsrv":
-                // if using windows authentication
-                if ($dbConfig["auth"]) {
-                    \SDF\Spark::connect(
-                        "sqlsrv:Server=" .
-                            $dbConfig["host"] .
-                            "," .
-                            ($dbConfig["port"] ?? "1433") .
-                            ";database=" .
-                            $dbConfig["name"],
-                    );
-                } else {
-                    \SDF\Spark::connect(
-                        "sqlsrv:Server=" .
-                            $dbConfig["host"] .
-                            "," .
-                            ($dbConfig["port"] ?? "1433") .
-                            ";database=" .
-                            $dbConfig["name"],
-                        $dbConfig["user"],
-                        $dbConfig["password"],
-                    );
-                }
-                break;
-            case "manual":
-                // Check if 'args' is provided and is an array
-                $args =
-                    isset($dbConfig["args"]) && is_array($dbConfig["args"])
-                        ? $dbConfig["args"]
-                        : [];
-
-                \SDF\Spark::connect($dbConfig["dsn"], ...$args);
-                break;
-            default:
-                throw new Exception(
-                    "Unsupported database driver: " . $dbConfig["driver"],
-                );
-        }
-    }
-} catch (Exception $e) {
-    SDF\Logger::log(
-        Level::FATAL,
-        "Database connection failed: " . $e->getMessage(),
-        ["exception" => $e],
-    );
-    throw new \SDF\HttpResponseException(
-        "Database connection failed.",
-        503,
-        $e,
-    );
+// Register Swagger routes if the Swagger controller file exists
+if (class_exists(\SDF\Swagger\SwaggerController::class) && SDF_ENV === "development") {
+    $router::add('/api/openapi.json', 'Swagger/SwaggerController/spec', 'GET');
+    $router::add('/api/docs', 'Swagger/SwaggerController/docs', 'GET');
 }
 
 $router::pathNotFound(SDF_EH_404);
@@ -259,21 +149,21 @@ foreach (Core::coreGetConfig("routes") as $route => $controller) {
         $router::add($route, $controller);
     }
 }
-// Initialize Session
-\SDF\Session::getInstance();
-SDF\Logger::log(Level::DEBUG, "Session initialized");
-
 $logger->log(Level::DEBUG, "Router: preparing to ignite");
-$bm->mark("__sdf__router__start__");
+if (SDF_BENCHMARK && isset($bm)) {
+    $bm->mark("__sdf__router__start__");
+}
 $router::ignite();
-$logger->log(Level::DEBUG, "Router: ignite completed", [
-    "elapsed_ms" => $bm->elapsedTime("__sdf__router__start__"),
-]);
-if (SDF_BENCHMARK) {
-    print_r(
-        '<script>console.log("SDF RENDERER DEBUG: Total Benchmark Result: ' .
-            $bm->elapsedTime("__sdf__router__start__") .
-            'ms.");</script>',
-    );
+if (SDF_BENCHMARK && isset($bm)) {
+    $logger->log(Level::DEBUG, "Router: ignite completed", [
+        "elapsed_ms" => $bm->elapsedTime("__sdf__router__start__"),
+    ]);
+    if (SDF_ENV === "development") {
+        print_r(
+            '<script>console.log("SDF RENDERER DEBUG: Total Benchmark Result: ' .
+                $bm->elapsedTime("__sdf__router__start__") .
+                'ms.");</script>',
+        );
+    }
 }
 // And This Is All :) Sdf must be initialized by now :)

--- a/sdf/__init.php
+++ b/sdf/__init.php
@@ -101,6 +101,12 @@ if (is_file($composerAutoload)) {
 
 // lets require our core, benchmark and router files.
 require SDF_DIR . "core/Core.php";
+
+// Load .env before config so env vars are available during config file parsing
+require_once SDF_DIR . "core/Env.php";
+require_once SDF_DIR . "core/helpers.php";
+\SDF\Env::load(SDF_ROOT . '/.env');
+
 Core::coreLoadConfigurations();
 
 // Initialize Logger early so we can write debug marks

--- a/sdf/__init.php
+++ b/sdf/__init.php
@@ -57,6 +57,9 @@ if (PHP_SAPI == "cli-server") {
         $temp = sys_get_temp_dir();
         @unlink($temp . "/sdf_routes.cache");
         @unlink($temp . "/sdf_config.cache");
+        if (function_exists('opcache_reset')) {
+            opcache_reset();
+        }
         echo "Cache cleared.";
         exit();
     }
@@ -69,6 +72,9 @@ if (PHP_SAPI == "cli-server") {
         $temp = sys_get_temp_dir();
         @unlink($temp . "/sdf_routes.cache");
         @unlink($temp . "/sdf_config.cache");
+        if (function_exists('opcache_reset')) {
+            opcache_reset();
+        }
         // Setting a reload signal will also refresh the browser
         file_put_contents($temp . "/sdf_reload.signal", time());
         echo "Cache refreshed. Browser will reload.";

--- a/sdf/__init.php
+++ b/sdf/__init.php
@@ -259,6 +259,10 @@ foreach (Core::coreGetConfig("routes") as $route => $controller) {
         $router::add($route, $controller);
     }
 }
+// Initialize Session
+\SDF\Session::getInstance();
+SDF\Logger::log(Level::DEBUG, "Session initialized");
+
 $logger->log(Level::DEBUG, "Router: preparing to ignite");
 $bm->mark("__sdf__router__start__");
 $router::ignite();

--- a/sdf/cli
+++ b/sdf/cli
@@ -1131,10 +1131,7 @@ class CLI
     {
         // Run wrk against the dev server and print results with 30s duration and 10 concurrent connections
         // save results to a file named benchmark_results.txt in the current directory
-        $port = in_array("-p", $this->argv)
-            ? $this->argv[array_search("-p", $this->argv) + 1]
-            : "8080";
-
+        $port = self::getPortArg();
         $duration = 30;
         $concurrency = 10;
 
@@ -1154,10 +1151,7 @@ class CLI
      */
     private function runBenchmarkDry(): void
     {
-        // run wrk and not save results to file, just print summary to console
-        $port = in_array("-p", $this->argv)
-            ? $this->argv[array_search("-p", $this->argv) + 1]
-            : "8080";
+        $port = self::getPortArg();
         $duration = 30;
         $concurrency = 10;
 
@@ -1211,9 +1205,7 @@ class CLI
      */
     private function handleDevServer(): void
     {
-        $port = in_array("-p", $this->argv)
-            ? $this->argv[array_search("-p", $this->argv) + 1]
-            : 8080;
+        $port = self::getPortArg();
         $quiet = in_array("-q", $this->argv);
         $live = in_array("--live", $this->argv);
 
@@ -1279,18 +1271,29 @@ class CLI
     /**
      * Spawn a background process to watch files and clear cache.
      */
+    private static function getPortArg(): int
+    {
+        $argv = $GLOBALS['argv'] ?? [];
+        $pIndex = array_search("-p", $argv);
+        if ($pIndex !== false && isset($argv[$pIndex + 1])) {
+            return (int) $argv[$pIndex + 1];
+        }
+        return 8080;
+    }
+
     private function startWatcher(): void
     {
         $lockFile = sys_get_temp_dir() . "/sdf_watcher.lock";
         if (file_exists($lockFile)) {
             $pid = (int) file_get_contents($lockFile);
-            if (function_exists("posix_getpgid")) {
-                if (posix_getpgid($pid)) {
-                    return; // Already running
+            if ($pid > 0) {
+                $running = false;
+                if (PHP_OS_FAMILY === 'Linux') {
+                    $running = file_exists("/proc/$pid");
+                } elseif (function_exists("posix_kill")) {
+                    $running = @posix_kill($pid, 0);
                 }
-            } else {
-                // posix not available; best-effort check: if pid is numeric and process exists
-                if ($pid > 0 && file_exists("/proc/$pid")) {
+                if ($running) {
                     return;
                 }
             }

--- a/sdf/cli
+++ b/sdf/cli
@@ -38,6 +38,15 @@ class CLI
         require_once SDF_DIR . "core/Core.php";
         Core::coreLoadConfigurations();
 
+        // Load Cache facade so clearCache() can flush it
+        if (!class_exists(\SDF\Cache\Cache::class, false)) {
+            require_once SDF_DIR . "core/Cache/CacheDriver.php";
+            require_once SDF_DIR . "core/Cache/Cache.php";
+            require_once SDF_DIR . "core/Cache/FileDriver.php";
+            require_once SDF_DIR . "core/Cache/RedisDriver.php";
+            require_once SDF_DIR . "core/Cache/MemcachedDriver.php";
+        }
+
         $this->config = Core::coreGetConfig("database") ?: [];
     }
 
@@ -1291,7 +1300,7 @@ class CLI
             }
         }
 
-        // Clear fuse cache
+        // Clear fuse cache (legacy raw files)
         $fuseCache = $temp . "/fuse_cache";
         if (is_dir($fuseCache)) {
             foreach (glob("$fuseCache/*") as $f) {
@@ -1299,6 +1308,22 @@ class CLI
                     unlink($f);
                 }
             }
+            $count++;
+        }
+
+        // Flush the Cache facade (FileDriver, Redis, Memcached)
+        if (class_exists(\SDF\Cache\Cache::class)) {
+            try {
+                \SDF\Cache\Cache::flush();
+                $count++;
+            } catch (\Throwable) {
+                // Cache facade may fail if config is incomplete; ignore
+            }
+        }
+
+        // Clear OPcache so changed PHP files (routes.php, etc.) are re-read
+        if (function_exists('opcache_reset')) {
+            opcache_reset();
             $count++;
         }
 

--- a/sdf/cli
+++ b/sdf/cli
@@ -1227,7 +1227,13 @@ class CLI
             $this->startWatcher();
         }
 
-        passthru("php -S localhost:$port index.php");
+        $frankenphpBin = trim(shell_exec("which frankenphp 2>/dev/null") ?? "");
+
+        if ($frankenphpBin !== "") {
+            passthru("frankenphp php-server --listen :$port");
+        } else {
+            passthru("php -S localhost:$port index.php");
+        }
 
         if (!$quiet) {
             echo "[INFO] Development server stopped.\n";

--- a/sdf/cli
+++ b/sdf/cli
@@ -40,11 +40,7 @@ class CLI
 
         // Load Cache facade so clearCache() can flush it
         if (!class_exists(\SDF\Cache\Cache::class, false)) {
-            require_once SDF_DIR . "core/Cache/CacheDriver.php";
-            require_once SDF_DIR . "core/Cache/Cache.php";
-            require_once SDF_DIR . "core/Cache/FileDriver.php";
-            require_once SDF_DIR . "core/Cache/RedisDriver.php";
-            require_once SDF_DIR . "core/Cache/MemcachedDriver.php";
+            require_once SDF_DIR . "core/Cache/__init.php";
         }
 
         $this->config = Core::coreGetConfig("database") ?: [];
@@ -89,6 +85,9 @@ class CLI
             case "benchmark":
             case "bench":
                 $this->handleBenchmark();
+                break;
+            case "swagger":
+                $this->handleSwagger();
                 break;
             default:
                 $this->printUsage();
@@ -1106,7 +1105,7 @@ class CLI
     // ─── Benchmark ────────────────────────────────────────────────────────────
 
     /**
-     * Route to database sub-commands.
+     * Route to benchmark sub-commands.
      */
     private function handleBenchmark(): void
     {
@@ -1125,6 +1124,9 @@ class CLI
         }
     }
 
+    /**
+     * Run wrk benchmark and save results to benchmark_results.txt.
+     */
     private function runBenchmark(): void
     {
         // Run wrk against the dev server and print results with 30s duration and 10 concurrent connections
@@ -1147,6 +1149,9 @@ class CLI
         exit($exit);
     }
 
+    /**
+     * Run wrk benchmark and print results to stdout (no file output).
+     */
     private function runBenchmarkDry(): void
     {
         // run wrk and not save results to file, just print summary to console
@@ -1163,6 +1168,40 @@ class CLI
             echo "Benchmark failed. Please ensure wrk is installed and in your PATH.\n";
         }
         exit($exit);
+    }
+
+    // ─── Swagger ───────────────────────────────────────────────────────────────
+
+    /**
+     * Handle swagger:generate command.
+     *
+     * Generates and writes openapi.json to the current directory
+     * or a specified output path.
+     */
+    private function handleSwagger(): void
+    {
+        if (count($this->argv) < 3) {
+            $this->printUsage();
+            exit(1);
+        }
+
+        if ($this->argv[2] !== "generate") {
+            echo "Usage: php sdf/cli swagger generate [output-path]\n";
+            exit(1);
+        }
+
+        $outputPath = $this->argv[3] ?? getcwd() . '/openapi.json';
+
+        $generator = new \SDF\Swagger\SwaggerGenerator(
+            title: 'SDF API',
+            apiVersion: SDF_VERSION,
+        );
+
+        $json = $generator->generate();
+        file_put_contents($outputPath, $json);
+
+        echo "OpenAPI spec written to: $outputPath\n";
+        exit(0);
     }
 
     // ─── Dev Server ───────────────────────────────────────────────────────────
@@ -1430,6 +1469,9 @@ class CLI
         echo "  format|fmt [options]        Run PHP-CS-Fixer (options passed directly, for example: --dry-run -v)\n";
         echo "\n";
         echo "  benchmark|bench [options]   Run wrk benchmarks against dev server (options passed directly, for example: --dry -p 8080)\n";
+        echo "\n";
+        echo "  swagger [action]             OpenAPI / Swagger documentation\n";
+        echo "    generate [output-path]     Generate openapi.json from controllers\n";
     }
 }
 

--- a/sdf/core/Auth/Auth.php
+++ b/sdf/core/Auth/Auth.php
@@ -1,0 +1,213 @@
+<?php
+
+namespace SDF\Auth;
+
+use SDF\Core;
+use SDF\Request;
+
+/**
+ * Project SDF Auth Facade
+ * Copyright devsimsek
+ * @package     SDF
+ * @subpackage  Auth
+ * @file        Auth.php
+ * @version     v1.0.0
+ * @author      devsimsek
+ * @copyright   Copyright (c) 2025, smskSoft, devsimsek
+ * @license     https://opensource.org/licenses/MIT	MIT License
+ * @link        https://github.com/devsimsek/project-sdf/wiki/libraries/auth
+ * @since       Version 2.0
+ * @filesource
+ */
+
+/**
+ * Static facade over the active authentication guard.
+ *
+ * Usage:
+ * ```php
+ * use SDF\Auth\Auth;
+ *
+ * if (Auth::check()) {
+ *     $user = Auth::user();
+ * }
+ * Auth::attempt(['email' => $email, 'password' => $pw]);
+ * Auth::logout();
+ * ```
+ *
+ * Configuration is read from `app/config/auth.php` (key: `auth`).
+ */
+class Auth
+{
+    /** @var array<string, Guard> Resolved guard instances. */
+    private static array $guards = [];
+
+    /**
+     * Get a guard instance by name.
+     *
+     * @param string|null $name Guard name (defaults to config default).
+     * @return Guard
+     */
+    public static function guard(?string $name = null): Guard
+    {
+        $name ??= self::getDefaultGuard();
+
+        if (!isset(self::$guards[$name])) {
+            self::$guards[$name] = self::resolveGuard($name);
+        }
+
+        return self::$guards[$name];
+    }
+
+    /**
+     * Determine if the current request has an authenticated user.
+     *
+     * @return bool
+     */
+    public static function check(): bool
+    {
+        return self::guard()->check();
+    }
+
+    /**
+     * Get the currently authenticated user.
+     *
+     * @return object|null
+     */
+    public static function user(): ?object
+    {
+        return self::guard()->user();
+    }
+
+    /**
+     * Log a user in using the default guard.
+     *
+     * @param object $user User model instance.
+     * @return void
+     */
+    public static function login(object $user): void
+    {
+        self::guard()->login($user);
+    }
+
+    /**
+     * Log the current user out.
+     *
+     * @return void
+     */
+    public static function logout(): void
+    {
+        self::guard()->logout();
+    }
+
+    /**
+     * Attempt to authenticate with credentials.
+     *
+     * @param array $credentials ['email' => '...', 'password' => '...']
+     * @return bool
+     */
+    public static function attempt(array $credentials): bool
+    {
+        return self::guard()->attempt($credentials);
+    }
+
+    /**
+     * Issue an access token (JWT guard only).
+     *
+     * @param object $user User model instance.
+     * @return string|null Encoded JWT or null if guard is not JwtGuard.
+     */
+    public static function issueToken(object $user): ?string
+    {
+        $guard = self::guard();
+
+        if ($guard instanceof JwtGuard) {
+            return $guard->issueToken($user);
+        }
+
+        return null;
+    }
+
+    /**
+     * Refresh an access token using a refresh token (JWT guard only).
+     *
+     * @param string $refreshToken A valid refresh JWT.
+     * @return array{access_token: string, refresh_token: string, token_type: string, expires_in: int}|null
+     */
+    public static function refresh(string $refreshToken): ?array
+    {
+        $guard = self::guard();
+
+        if ($guard instanceof JwtGuard) {
+            return $guard->refresh($refreshToken);
+        }
+
+        return null;
+    }
+
+    /**
+     * Replace a resolved guard (useful in tests).
+     *
+     * @param string $name  Guard name.
+     * @param Guard  $guard Guard instance.
+     * @return void
+     */
+    public static function setGuard(string $name, Guard $guard): void
+    {
+        self::$guards[$name] = $guard;
+    }
+
+    /**
+     * Reset all resolved guards (useful in tests).
+     *
+     * @return void
+     */
+    public static function reset(): void
+    {
+        self::$guards = [];
+    }
+
+    /**
+     * Get the default guard name from config.
+     *
+     * @return string
+     */
+    private static function getDefaultGuard(): string
+    {
+        $config = Core::coreGetConfig('auth') ?: [];
+        return $config['default'] ?? 'session';
+    }
+
+    /**
+     * Resolve and construct a guard from config.
+     *
+     * @param string $name Guard name.
+     * @return Guard
+     * @throws \RuntimeException If the guard is not configured.
+     */
+    private static function resolveGuard(string $name): Guard
+    {
+        $config = Core::coreGetConfig('auth') ?: [];
+        $guardConfig = $config['guards'][$name] ?? [];
+
+        if (empty($guardConfig)) {
+            throw new \RuntimeException("Auth guard '$name' is not configured.");
+        }
+
+        $providerName = $guardConfig['provider'] ?? 'users';
+        $providerConfig = $config['providers'][$providerName] ?? [];
+
+        $model = $providerConfig['model'] ?? \App\Models\User::class;
+        $provider = new UserProvider($model);
+
+        return match ($name) {
+            'jwt' => new JwtGuard(
+                $provider,
+                new Request(),
+                $guardConfig['secret'] ?? '',
+                (int) ($guardConfig['ttl'] ?? 3600),
+                (int) ($guardConfig['refresh_ttl'] ?? 604800),
+            ),
+            default => new SessionGuard($provider),
+        };
+    }
+}

--- a/sdf/core/Auth/AuthMiddleware.php
+++ b/sdf/core/Auth/AuthMiddleware.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace SDF\Auth;
+
+use Closure;
+use SDF\HttpResponseException;
+use SDF\Middleware;
+use SDF\Request;
+
+/**
+ * Project SDF Auth Middleware
+ * Copyright devsimsek
+ * @package     SDF
+ * @subpackage  Auth
+ * @file        AuthMiddleware.php
+ * @version     v1.0.0
+ * @author      devsimsek
+ * @copyright   Copyright (c) 2025, smskSoft, devsimsek
+ * @license     https://opensource.org/licenses/MIT	MIT License
+ * @link        https://github.com/devsimsek/project-sdf/wiki/libraries/auth
+ * @since       Version 2.0
+ * @filesource
+ */
+
+/**
+ * Pipeline middleware that rejects unauthenticated requests with 401.
+ *
+ * Register in your route config:
+ * ```php
+ * Router::middleware(\SDF\Auth\AuthMiddleware::class);
+ * ```
+ *
+ * To use a non-default guard, subclass and override the constructor
+ * or call `Auth::guard('jwt')` before the middleware runs.
+ */
+class AuthMiddleware implements Middleware
+{
+    /** @var string Guard name to use for authentication. */
+    protected string $guard;
+
+    /**
+     * @param string $guard Guard name (default: 'session').
+     */
+    public function __construct(string $guard = 'session')
+    {
+        $this->guard = $guard;
+    }
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param Request $request
+     * @param Closure $next
+     * @return mixed
+     * @throws HttpResponseException When unauthenticated.
+     */
+    public function handle(Request $request, Closure $next): mixed
+    {
+        if (!Auth::guard($this->guard)->check()) {
+            throw new HttpResponseException('Unauthenticated', 401);
+        }
+
+        return $next($request);
+    }
+}

--- a/sdf/core/Auth/Guard.php
+++ b/sdf/core/Auth/Guard.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace SDF\Auth;
+
+/**
+ * Project SDF Auth Guard Contract
+ * Copyright devsimsek
+ * @package     SDF
+ * @subpackage  Auth
+ * @file        Guard.php
+ * @version     v1.0.0
+ * @author      devsimsek
+ * @copyright   Copyright (c) 2025, smskSoft, devsimsek
+ * @license     https://opensource.org/licenses/MIT	MIT License
+ * @link        https://github.com/devsimsek/project-sdf/wiki/libraries/auth
+ * @since       Version 2.0
+ * @filesource
+ */
+
+/**
+ * Contract for authentication guards.
+ *
+ * Guards define how users are authenticated and retrieved
+ * during a request life-cycle (stateless JWT or session-based).
+ */
+interface Guard
+{
+    /**
+     * Determine if the current request has an authenticated user.
+     *
+     * @return bool
+     */
+    public function check(): bool;
+
+    /**
+     * Get the currently authenticated user.
+     *
+     * @return object|null
+     */
+    public function user(): ?object;
+
+    /**
+     * Log a user in.
+     *
+     * @param object $user User model instance.
+     * @return void
+     */
+    public function login(object $user): void;
+
+    /**
+     * Log the current user out.
+     *
+     * @return void
+     */
+    public function logout(): void;
+
+    /**
+     * Attempt to authenticate with credentials.
+     *
+     * @param array $credentials ['email' => '...', 'password' => '...']
+     * @return bool True on success.
+     */
+    public function attempt(array $credentials): bool;
+}

--- a/sdf/core/Auth/JwtGuard.php
+++ b/sdf/core/Auth/JwtGuard.php
@@ -1,0 +1,315 @@
+<?php
+
+namespace SDF\Auth;
+
+use SDF\Request;
+
+/**
+ * Project SDF JWT Guard
+ * Copyright devsimsek
+ * @package     SDF
+ * @subpackage  Auth
+ * @file        JwtGuard.php
+ * @version     v1.0.0
+ * @author      devsimsek
+ * @copyright   Copyright (c) 2025, smskSoft, devsimsek
+ * @license     https://opensource.org/licenses/MIT	MIT License
+ * @link        https://github.com/devsimsek/project-sdf/wiki/libraries/auth
+ * @since       Version 2.0
+ * @filesource
+ */
+
+/**
+ * Authenticate users via stateless JWT bearer tokens.
+ *
+ * Implements HS256 JWT (HMAC-SHA256) with access + refresh token support.
+ * Tokens are read from the `Authorization: Bearer` header.
+ */
+class JwtGuard implements Guard
+{
+    private UserProvider $provider;
+    private Request $request;
+    private string $secret;
+    private int $ttl;
+    private int $refreshTtl;
+
+    private ?object $userInstance = null;
+
+    /**
+     * @param UserProvider $provider   User loader instance.
+     * @param Request      $request    Current request (for bearer token extraction).
+     * @param string       $secret     HMAC secret key.
+     * @param int          $ttl        Access token TTL in seconds.
+     * @param int          $refreshTtl Refresh token TTL in seconds.
+     */
+    public function __construct(
+        UserProvider $provider,
+        Request $request,
+        string $secret,
+        int $ttl = 3600,
+        int $refreshTtl = 604800,
+    ) {
+        $this->provider = $provider;
+        $this->request = $request;
+        $this->secret = $secret;
+        $this->ttl = $ttl;
+        $this->refreshTtl = $refreshTtl;
+    }
+
+    /**
+     * Determine if a valid bearer token is present.
+     *
+     * @return bool
+     */
+    public function check(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * Get the authenticated user from the bearer token.
+     *
+     * @return object|null
+     */
+    public function user(): ?object
+    {
+        if ($this->userInstance !== null) {
+            return $this->userInstance;
+        }
+
+        $token = $this->request->bearerToken();
+
+        if ($token === null) {
+            return null;
+        }
+
+        $payload = $this->decode($token);
+
+        if ($payload === null || ($payload->type ?? 'access') !== 'access') {
+            return null;
+        }
+
+        $this->userInstance = $this->provider->retrieveById($payload->sub);
+        return $this->userInstance;
+    }
+
+    /**
+     * Set the authenticated user (does not issue a token).
+     *
+     * @param object $user User model instance.
+     * @return void
+     */
+    public function login(object $user): void
+    {
+        $this->userInstance = $user;
+    }
+
+    /**
+     * Clear the authenticated user.
+     *
+     * @return void
+     */
+    public function logout(): void
+    {
+        $this->userInstance = null;
+    }
+
+    /**
+     * Attempt to authenticate with credentials.
+     *
+     * @param array $credentials ['email' => '...', 'password' => '...']
+     * @return bool
+     */
+    public function attempt(array $credentials): bool
+    {
+        $user = $this->provider->retrieveByCredentials($credentials);
+
+        if ($user === null) {
+            return false;
+        }
+
+        if (!$this->provider->validateCredentials($user, $credentials)) {
+            return false;
+        }
+
+        $this->login($user);
+        return true;
+    }
+
+    /**
+     * Encode a payload into a signed JWT.
+     *
+     * @param array $payload Token claims.
+     * @return string Encoded JWT string.
+     */
+    public function encode(array $payload): string
+    {
+        $header = ['alg' => 'HS256', 'typ' => 'JWT'];
+        $segments = [];
+
+        $segments[] = $this->base64UrlEncode(json_encode($header));
+        $segments[] = $this->base64UrlEncode(json_encode($payload));
+
+        $signingInput = implode('.', $segments);
+        $signature = $this->sign($signingInput);
+        $segments[] = $this->base64UrlEncode($signature);
+
+        return implode('.', $segments);
+    }
+
+    /**
+     * Decode and verify a JWT. Returns null on any failure.
+     *
+     * @param string $token Encoded JWT string.
+     * @return object|null Decoded payload or null.
+     */
+    public function decode(string $token): ?object
+    {
+        $parts = explode('.', $token);
+
+        if (count($parts) !== 3) {
+            return null;
+        }
+
+        [$headerB64, $payloadB64, $signatureB64] = $parts;
+
+        $signingInput = "$headerB64.$payloadB64";
+        $signature = $this->base64UrlDecode($signatureB64);
+
+        if ($signature === false) {
+            return null;
+        }
+
+        if (!$this->verify($signingInput, $signature)) {
+            return null;
+        }
+
+        $payload = json_decode($this->base64UrlDecode($payloadB64));
+
+        if (!$payload || !isset($payload->exp) || !isset($payload->sub)) {
+            return null;
+        }
+
+        if ($payload->exp < time()) {
+            return null;
+        }
+
+        return $payload;
+    }
+
+    /**
+     * Issue a signed access token for the given user.
+     *
+     * @param object $user User model instance.
+     * @return string Encoded JWT.
+     */
+    public function issueToken(object $user): string
+    {
+        return $this->encode([
+            'sub' => $user->id ?? null,
+            'iat' => time(),
+            'exp' => time() + $this->ttl,
+            'type' => 'access',
+        ]);
+    }
+
+    /**
+     * Issue a signed refresh token for the given user.
+     *
+     * @param object $user User model instance.
+     * @return string Encoded JWT.
+     */
+    public function issueRefreshToken(object $user): string
+    {
+        return $this->encode([
+            'sub' => $user->id ?? null,
+            'iat' => time(),
+            'exp' => time() + $this->refreshTtl,
+            'type' => 'refresh',
+        ]);
+    }
+
+    /**
+     * Attempt to refresh an access token using a refresh token.
+     *
+     * @param string $refreshToken A valid refresh JWT.
+     * @return array{access_token: string, refresh_token: string, token_type: string, expires_in: int}|null
+     */
+    public function refresh(string $refreshToken): ?array
+    {
+        $payload = $this->decode($refreshToken);
+
+        if ($payload === null || ($payload->type ?? '') !== 'refresh') {
+            return null;
+        }
+
+        $user = $this->provider->retrieveById($payload->sub);
+
+        if ($user === null) {
+            return null;
+        }
+
+        return [
+            'access_token' => $this->issueToken($user),
+            'refresh_token' => $this->issueRefreshToken($user),
+            'token_type' => 'Bearer',
+            'expires_in' => $this->ttl,
+        ];
+    }
+
+    /**
+     * Sign an input string using HMAC-SHA256.
+     *
+     * @param string $input Data to sign.
+     * @return string Raw binary signature.
+     */
+    private function sign(string $input): string
+    {
+        return hash_hmac('sha256', $input, $this->secret, true);
+    }
+
+    /**
+     * Verify a signature against an input string using timing-safe comparison.
+     *
+     * @param string $input     Original data.
+     * @param string $signature Signature to verify.
+     * @return bool
+     */
+    private function verify(string $input, string $signature): bool
+    {
+        $expected = $this->sign($input);
+
+        if (function_exists('hash_equals')) {
+            return hash_equals($expected, $signature);
+        }
+
+        return $expected === $signature;
+    }
+
+    /**
+     * Base64URL encode (RFC 4648 section 5, no padding).
+     *
+     * @param string $data Raw data.
+     * @return string URL-safe base64 string.
+     */
+    private function base64UrlEncode(string $data): string
+    {
+        return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
+    }
+
+    /**
+     * Base64URL decode.
+     *
+     * @param string $data URL-safe base64 string.
+     * @return string|false Decoded data or false on failure.
+     */
+    private function base64UrlDecode(string $data): string|false
+    {
+        $remainder = strlen($data) % 4;
+        if ($remainder) {
+            $data .= str_repeat('=', 4 - $remainder);
+        }
+
+        return base64_decode(strtr($data, '-_', '+/'));
+    }
+}

--- a/sdf/core/Auth/JwtGuard.php
+++ b/sdf/core/Auth/JwtGuard.php
@@ -49,6 +49,9 @@ class JwtGuard implements Guard
         int $ttl = 3600,
         int $refreshTtl = 604800,
     ) {
+        if ($secret === '') {
+            throw new \RuntimeException('JWT guard: secret must not be empty. Set JWT_SECRET in .env or config/auth.php.');
+        }
         $this->provider = $provider;
         $this->request = $request;
         $this->secret = $secret;

--- a/sdf/core/Auth/SessionGuard.php
+++ b/sdf/core/Auth/SessionGuard.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace SDF\Auth;
+
+/**
+ * Project SDF Session Guard
+ * Copyright devsimsek
+ * @package     SDF
+ * @subpackage  Auth
+ * @file        SessionGuard.php
+ * @version     v1.0.0
+ * @author      devsimsek
+ * @copyright   Copyright (c) 2025, smskSoft, devsimsek
+ * @license     https://opensource.org/licenses/MIT	MIT License
+ * @link        https://github.com/devsimsek/project-sdf/wiki/libraries/auth
+ * @since       Version 2.0
+ * @filesource
+ */
+
+/**
+ * Authenticate users via PHP sessions.
+ *
+ * Stores the authenticated user's ID in `$_SESSION['_auth_id']`
+ * and retrieves the full model on subsequent requests.
+ */
+class SessionGuard implements Guard
+{
+    /** @var UserProvider User loader. */
+    private UserProvider $provider;
+
+    /** @var object|null Cached user instance. */
+    private ?object $userInstance = null;
+
+    /**
+     * @param UserProvider $provider User loader instance.
+     */
+    public function __construct(UserProvider $provider)
+    {
+        $this->provider = $provider;
+    }
+
+    /**
+     * Determine if the current session has an authenticated user.
+     *
+     * @return bool
+     */
+    public function check(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * Get the currently authenticated user.
+     *
+     * @return object|null
+     */
+    public function user(): ?object
+    {
+        if ($this->userInstance !== null) {
+            return $this->userInstance;
+        }
+
+        $id = $_SESSION['_auth_id'] ?? null;
+
+        if ($id === null) {
+            return null;
+        }
+
+        $this->userInstance = $this->provider->retrieveById($id);
+        return $this->userInstance;
+    }
+
+    /**
+     * Log a user into the session.
+     *
+     * @param object $user User model instance.
+     * @return void
+     */
+    public function login(object $user): void
+    {
+        $this->userInstance = $user;
+        $_SESSION['_auth_id'] = $user->id ?? null;
+    }
+
+    /**
+     * Log the current user out.
+     *
+     * @return void
+     */
+    public function logout(): void
+    {
+        $this->userInstance = null;
+        unset($_SESSION['_auth_id']);
+    }
+
+    /**
+     * Attempt to authenticate a user with the given credentials.
+     *
+     * @param array $credentials ['email' => '...', 'password' => '...']
+     * @return bool True on success, false on failure.
+     */
+    public function attempt(array $credentials): bool
+    {
+        $user = $this->provider->retrieveByCredentials($credentials);
+
+        if ($user === null) {
+            return false;
+        }
+
+        if (!$this->provider->validateCredentials($user, $credentials)) {
+            return false;
+        }
+
+        $this->login($user);
+        return true;
+    }
+}

--- a/sdf/core/Auth/SessionGuard.php
+++ b/sdf/core/Auth/SessionGuard.php
@@ -2,6 +2,8 @@
 
 namespace SDF\Auth;
 
+use SDF\Session;
+
 /**
  * Project SDF Session Guard
  * Copyright devsimsek
@@ -20,7 +22,7 @@ namespace SDF\Auth;
 /**
  * Authenticate users via PHP sessions.
  *
- * Stores the authenticated user's ID in `$_SESSION['_auth_id']`
+ * Stores the authenticated user's ID in `session key '_auth_id'`
  * and retrieves the full model on subsequent requests.
  */
 class SessionGuard implements Guard
@@ -60,7 +62,8 @@ class SessionGuard implements Guard
             return $this->userInstance;
         }
 
-        $id = $_SESSION['_auth_id'] ?? null;
+        $session = Session::getInstance();
+        $id = $session->get('_auth_id');
 
         if ($id === null) {
             return null;
@@ -79,7 +82,9 @@ class SessionGuard implements Guard
     public function login(object $user): void
     {
         $this->userInstance = $user;
-        $_SESSION['_auth_id'] = $user->id ?? null;
+        $session = Session::getInstance();
+        $session->set('_auth_id', $user->id ?? null);
+        $session->regenerate(true);
     }
 
     /**
@@ -90,7 +95,9 @@ class SessionGuard implements Guard
     public function logout(): void
     {
         $this->userInstance = null;
-        unset($_SESSION['_auth_id']);
+        $session = Session::getInstance();
+        $session->remove('_auth_id');
+        $session->regenerate(true);
     }
 
     /**

--- a/sdf/core/Auth/UserProvider.php
+++ b/sdf/core/Auth/UserProvider.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace SDF\Auth;
+
+/**
+ * Project SDF Auth User Provider
+ * Copyright devsimsek
+ * @package     SDF
+ * @subpackage  Auth
+ * @file        UserProvider.php
+ * @version     v1.0.0
+ * @author      devsimsek
+ * @copyright   Copyright (c) 2025, smskSoft, devsimsek
+ * @license     https://opensource.org/licenses/MIT	MIT License
+ * @link        https://github.com/devsimsek/project-sdf/wiki/libraries/auth
+ * @since       Version 2.0
+ * @filesource
+ */
+
+/**
+ * Load users from storage for authentication guards.
+ */
+class UserProvider
+{
+    /** @var class-string FQCN of the user model. */
+    private string $model;
+
+    /**
+     * @param class-string $model User model class (e.g. \App\Models\User::class).
+     */
+    public function __construct(string $model)
+    {
+        $this->model = $model;
+    }
+
+    /**
+     * Retrieve a user by their primary key.
+     *
+     * @param mixed $id Primary key value.
+     * @return object|null
+     */
+    public function retrieveById(mixed $id): ?object
+    {
+        $model = $this->model;
+        return $model::find($id);
+    }
+
+    /**
+     * Retrieve a user by the given credentials (single field match).
+     *
+     * Iterates over the credentials array and returns the first match.
+     * Typically used with ['email' => $email] or ['username' => $name].
+     *
+     * @param array $credentials Key-value pair to search by.
+     * @return object|null
+     */
+    public function retrieveByCredentials(array $credentials): ?object
+    {
+        $model = $this->model;
+
+        foreach ($credentials as $key => $value) {
+            return $model::where($key, $value)->first();
+        }
+
+        return null;
+    }
+
+    /**
+     * Validate the given credentials against a user instance.
+     *
+     * Expects the user model to expose a `password` property
+     * containing the bcrypt hash.
+     *
+     * @param object $user        User model instance.
+     * @param array  $credentials ['password' => '...'] to verify.
+     * @return bool
+     */
+    public function validateCredentials(object $user, array $credentials): bool
+    {
+        return password_verify(
+            $credentials['password'] ?? '',
+            $user->password ?? '',
+        );
+    }
+
+    /**
+     * Rehash the password if the current bcrypt cost is outdated.
+     *
+     * @param object $user    User model instance with a `password` property.
+     * @param string $password Plain-text password to rehash.
+     * @return void
+     */
+    public function rehashPasswordIfNeeded(object $user, string $password): void
+    {
+        if (password_needs_rehash($user->password ?? '', PASSWORD_BCRYPT)) {
+            $user->password = password_hash($password, PASSWORD_BCRYPT);
+            $user->save();
+        }
+    }
+}

--- a/sdf/core/Cache/Cache.php
+++ b/sdf/core/Cache/Cache.php
@@ -216,7 +216,8 @@ class Cache
         }
 
         $fqcn = __NAMESPACE__ . '\\' . $class;
-        return new $fqcn($config[$driver] ?? []);
+        $configKey = ($class === 'FileDriver') ? 'file' : $driver;
+        return new $fqcn($config[$configKey] ?? []);
     }
 
     /**

--- a/sdf/core/Cache/Cache.php
+++ b/sdf/core/Cache/Cache.php
@@ -22,7 +22,7 @@ use DateTime;
 use SDF\Core;
 
 /**
- * Cache facade — PSR-16 (SimpleCache) compliant static proxy.
+ * Cache facade - PSR-16 (SimpleCache) compliant static proxy.
  *
  * Usage:
  *   Cache::set('key', $value, 3600);
@@ -204,11 +204,19 @@ class Cache
         $config = Core::coreGetConfig('cache') ?: [];
         $driver = $config['driver'] ?? 'file';
 
-        return match ($driver) {
-            'redis' => new RedisDriver($config['redis'] ?? []),
-            'memcached' => new MemcachedDriver($config['memcached'] ?? []),
-            default => new FileDriver($config['file'] ?? []),
-        };
+        $driverMap = [
+            'redis' => 'RedisDriver',
+            'memcached' => 'MemcachedDriver',
+            'file' => 'FileDriver',
+        ];
+        $class = $driverMap[$driver] ?? 'FileDriver';
+        $file = __DIR__ . '/' . $class . '.php';
+        if (is_file($file)) {
+            require_once $file;
+        }
+
+        $fqcn = __NAMESPACE__ . '\\' . $class;
+        return new $fqcn($config[$driver] ?? []);
     }
 
     /**

--- a/sdf/core/Cache/FileDriver.php
+++ b/sdf/core/Cache/FileDriver.php
@@ -321,7 +321,7 @@ class FileDriver implements CacheDriver
     {
         $index = $this->loadTagIndex();
         foreach ($index as $tag => $keys) {
-            $index[$tag] = array_values(array_filter($keys, fn($k) => $k !== $key));
+            $index[$tag] = array_values(array_filter($keys, fn ($k) => $k !== $key));
             if (empty($index[$tag])) {
                 unset($index[$tag]);
             }

--- a/sdf/core/Cache/FileDriver.php
+++ b/sdf/core/Cache/FileDriver.php
@@ -262,7 +262,7 @@ class FileDriver implements CacheDriver
         if ($content === false) {
             return null;
         }
-        $data = unserialize($content);
+        $data = unserialize($content, ['allowed_classes' => false]);
         if (!is_array($data)) {
             return null;
         }
@@ -342,7 +342,7 @@ class FileDriver implements CacheDriver
         if ($content === false) {
             return [];
         }
-        $data = unserialize($content);
+        $data = unserialize($content, ['allowed_classes' => false]);
         return is_array($data) ? $data : [];
     }
 

--- a/sdf/core/Cache/MemcachedDriver.php
+++ b/sdf/core/Cache/MemcachedDriver.php
@@ -297,7 +297,7 @@ class MemcachedDriver implements CacheDriver
     {
         $tagIndex = $this->loadTagIndex();
         foreach ($tagIndex as $tag => $keys) {
-            $tagIndex[$tag] = array_values(array_filter($keys, fn($k) => $k !== $key));
+            $tagIndex[$tag] = array_values(array_filter($keys, fn ($k) => $k !== $key));
             if (empty($tagIndex[$tag])) {
                 unset($tagIndex[$tag]);
             }

--- a/sdf/core/Cache/RedisDriver.php
+++ b/sdf/core/Cache/RedisDriver.php
@@ -94,7 +94,7 @@ class RedisDriver implements CacheDriver
         if ($value === false) {
             return $default;
         }
-        $data = unserialize($value);
+        $data = unserialize($value, ['allowed_classes' => false]);
         return $data !== false ? $data : $default;
     }
 
@@ -149,7 +149,13 @@ class RedisDriver implements CacheDriver
         if (!$this->available) {
             return false;
         }
-        $keys = $this->redis->keys($this->prefix . '*');
+        $iterator = null;
+        $keys = [];
+        while ($ret = $this->redis->scan($iterator, $this->prefix . '*')) {
+            foreach ($ret as $key) {
+                $keys[] = $key;
+            }
+        }
         if (!empty($keys)) {
             $this->redis->del($keys);
         }
@@ -180,7 +186,7 @@ class RedisDriver implements CacheDriver
         $result = [];
         foreach ($values as $i => $v) {
             $originalKey = $map[$prefixed[$i]];
-            $data = $v !== false ? unserialize($v) : false;
+            $data = is_string($v) ? unserialize($v, ['allowed_classes' => false]) : false;
             $result[$originalKey] = $data !== false ? $data : $default;
         }
         return $result;

--- a/sdf/core/Cache/__init.php
+++ b/sdf/core/Cache/__init.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * smskSoft SDF Cache - Bootstrap require.
+ * Single entry point for the Cache facade (interface + facade class).
+ *
+ * @package     SDF
+ * @subpackage  SDF Cache
+ * @filesource
+ */
+
+require_once __DIR__ . '/CacheDriver.php';
+require_once __DIR__ . '/Cache.php';

--- a/sdf/core/Core.php
+++ b/sdf/core/Core.php
@@ -118,7 +118,7 @@ trait CoreUtilities
         if (is_file($cacheFile)) {
             $raw = file_get_contents($cacheFile);
             // Try new format (serialize) first, fall back to old format (var_export)
-            $config = @unserialize($raw);
+            $config = @unserialize($raw, ['allowed_classes' => false]);
             if ($config !== false) {
                 \SDF\Core::$config = $config;
                 return;

--- a/sdf/core/Core.php
+++ b/sdf/core/Core.php
@@ -284,12 +284,12 @@ trait CoreUtilities
  */
 class Core
 {
+    use CoreUtilities;
+
     /** @var array Stores the classes that have been loaded */
     public static array $isLoaded = [];
     /** @var array Stores the classes that have been loaded */
     public static array $classes = [];
     /** @var array Stores the configurations that have been loaded */
     public static array $config = [];
-
-    use CoreUtilities;
 }

--- a/sdf/core/Core.php
+++ b/sdf/core/Core.php
@@ -115,9 +115,22 @@ trait CoreUtilities
         string $directory = "config",
     ): void {
         $cacheFile = sys_get_temp_dir() . "/sdf_config.cache";
-        if (file_exists($cacheFile)) {
-            \SDF\Core::$config = require $cacheFile;
-            return;
+        if (is_file($cacheFile)) {
+            $raw = file_get_contents($cacheFile);
+            // Try new format (serialize) first, fall back to old format (var_export)
+            $config = @unserialize($raw);
+            if ($config !== false) {
+                \SDF\Core::$config = $config;
+                return;
+            }
+            // Old format: PHP return statement from var_export
+            $config = require $cacheFile;
+            if (is_array($config)) {
+                \SDF\Core::$config = $config;
+                // Rewrite in new format for next time
+                file_put_contents($cacheFile, serialize($config));
+                return;
+            }
         }
 
         foreach (
@@ -132,7 +145,7 @@ trait CoreUtilities
                 $directory .
                 DIRECTORY_SEPARATOR .
                 $file;
-            if (file_exists($filePath)) {
+            if (is_file($filePath)) {
                 if (str_ends_with($file, ".json")) {
                     $config = json_decode(file_get_contents($filePath), true);
                 } else {
@@ -165,7 +178,7 @@ trait CoreUtilities
         }
         file_put_contents(
             $cacheFile,
-            "<?php return " . var_export(\SDF\Core::$config, true) . ";",
+            serialize(\SDF\Core::$config),
         );
         chmod($cacheFile, 0600);
     }

--- a/sdf/core/Encryption/Encrypter.php
+++ b/sdf/core/Encryption/Encrypter.php
@@ -31,6 +31,9 @@ class Encrypter
     private string $key;
     private string $cipher;
 
+    private const HMAC_ALGO = 'sha256';
+    private const HMAC_LEN = 32;
+
     /**
      * @param string      $key    Base64-encoded 32-byte key (or raw 32 bytes).
      * @param string|null $cipher OpenSSL cipher method (default: AES-256-CBC).
@@ -54,10 +57,12 @@ class Encrypter
     }
 
     /**
-     * Encrypt a value.
+     * Encrypt a value (encrypt-then-MAC).
+     *
+     * Format: base64( iv || ciphertext || hmac )
      *
      * @param string $value Plaintext.
-     * @return string Base64-encoded ciphertext (IV + encrypted data).
+     * @return string Base64-encoded ciphertext with HMAC integrity tag.
      */
     public function encrypt(string $value): string
     {
@@ -70,13 +75,15 @@ class Encrypter
             throw new RuntimeException('Encryption failed.');
         }
 
-        return base64_encode($iv . $encrypted);
+        $hmac = hash_hmac(self::HMAC_ALGO, $iv . $encrypted, $this->key, true);
+
+        return base64_encode($iv . $encrypted . $hmac);
     }
 
     /**
-     * Decrypt a value.
+     * Decrypt a value (verify-then-decrypt).
      *
-     * @param string $payload Base64-encoded ciphertext (IV + encrypted data).
+     * @param string $payload Base64-encoded IV + ciphertext + HMAC.
      * @return string Plaintext.
      */
     public function decrypt(string $payload): string
@@ -88,17 +95,24 @@ class Encrypter
 
         $ivLen = openssl_cipher_iv_length($this->cipher);
 
-        if (strlen($data) < $ivLen) {
+        if (strlen($data) < $ivLen + self::HMAC_LEN) {
             throw new RuntimeException('Invalid encrypted payload (too short).');
         }
 
         $iv = substr($data, 0, $ivLen);
-        $encrypted = substr($data, $ivLen);
+        $encrypted = substr($data, $ivLen, -self::HMAC_LEN);
+        $expectedMac = substr($data, -self::HMAC_LEN);
+
+        $actualMac = hash_hmac(self::HMAC_ALGO, $iv . $encrypted, $this->key, true);
+
+        if (!hash_equals($expectedMac, $actualMac)) {
+            throw new RuntimeException('Decryption failed (MAC mismatch — data tampered or wrong key).');
+        }
 
         $decrypted = openssl_decrypt($encrypted, $this->cipher, $this->key, OPENSSL_RAW_DATA, $iv);
 
         if ($decrypted === false) {
-            throw new RuntimeException('Decryption failed (wrong key or corrupted data).');
+            throw new RuntimeException('Decryption failed (corrupted data).');
         }
 
         return $decrypted;

--- a/sdf/core/Encryption/Encrypter.php
+++ b/sdf/core/Encryption/Encrypter.php
@@ -1,0 +1,123 @@
+<?php
+
+/**
+ * smskSoft SDF Encryption
+ * Copyright devsimsek
+ * @package     SDF
+ * @subpackage  SDF Encryption
+ * @file        Encrypter.php
+ * @version     v1.0.0
+ * @author      devsimsek
+ * @copyright   Copyright (c) 2025, smskSoft, devsimsek
+ * @license     https://opensource.org/licenses/MIT	MIT License
+ * @since       Version 2.2
+ * @filesource
+ */
+
+namespace SDF\Encryption;
+
+use RuntimeException;
+
+/**
+ * AES-256-CBC encrypt/decrypt for sensitive data.
+ *
+ * Usage:
+ *   $enc = new Encrypter('base64-32-byte-key');
+ *   $ciphertext = $enc->encrypt('secret data');
+ *   $plaintext  = $enc->decrypt($ciphertext);
+ */
+class Encrypter
+{
+    private string $key;
+    private string $cipher;
+
+    /**
+     * @param string      $key    Base64-encoded 32-byte key (or raw 32 bytes).
+     * @param string|null $cipher OpenSSL cipher method (default: AES-256-CBC).
+     */
+    public function __construct(string $key, ?string $cipher = null)
+    {
+        if (strlen($key) === 44 && base64_encode(base64_decode($key, true)) === $key) {
+            $key = base64_decode($key, true);
+        }
+
+        if (strlen($key) !== 32) {
+            throw new RuntimeException('Encryption key must be 32 bytes (base64-encoded or raw).');
+        }
+
+        $this->key = $key;
+        $this->cipher = strtolower($cipher ?? 'AES-256-CBC');
+
+        if (!in_array($this->cipher, openssl_get_cipher_methods(), true)) {
+            throw new RuntimeException("Unsupported cipher: {$this->cipher}");
+        }
+    }
+
+    /**
+     * Encrypt a value.
+     *
+     * @param string $value Plaintext.
+     * @return string Base64-encoded ciphertext (IV + encrypted data).
+     */
+    public function encrypt(string $value): string
+    {
+        $ivLen = openssl_cipher_iv_length($this->cipher);
+        $iv = openssl_random_pseudo_bytes($ivLen);
+
+        $encrypted = openssl_encrypt($value, $this->cipher, $this->key, OPENSSL_RAW_DATA, $iv);
+
+        if ($encrypted === false) {
+            throw new RuntimeException('Encryption failed.');
+        }
+
+        return base64_encode($iv . $encrypted);
+    }
+
+    /**
+     * Decrypt a value.
+     *
+     * @param string $payload Base64-encoded ciphertext (IV + encrypted data).
+     * @return string Plaintext.
+     */
+    public function decrypt(string $payload): string
+    {
+        $data = base64_decode($payload, true);
+        if ($data === false) {
+            throw new RuntimeException('Invalid encrypted payload (not valid base64).');
+        }
+
+        $ivLen = openssl_cipher_iv_length($this->cipher);
+
+        if (strlen($data) < $ivLen) {
+            throw new RuntimeException('Invalid encrypted payload (too short).');
+        }
+
+        $iv = substr($data, 0, $ivLen);
+        $encrypted = substr($data, $ivLen);
+
+        $decrypted = openssl_decrypt($encrypted, $this->cipher, $this->key, OPENSSL_RAW_DATA, $iv);
+
+        if ($decrypted === false) {
+            throw new RuntimeException('Decryption failed (wrong key or corrupted data).');
+        }
+
+        return $decrypted;
+    }
+
+    /**
+     * Resolve an encrypter instance from app/config/encryption.php.
+     *
+     * @return self
+     */
+    public static function fromConfig(): self
+    {
+        $config = \SDF\Core::coreGetConfig('encryption') ?: [];
+
+        $key = $config['key'] ?? '';
+        if ($key === '') {
+            throw new RuntimeException('Encryption key not configured. Set APP_KEY in .env or config/encryption.php.');
+        }
+
+        return new self($key, $config['cipher'] ?? null);
+    }
+}

--- a/sdf/core/Env.php
+++ b/sdf/core/Env.php
@@ -161,10 +161,13 @@ class Env
     /**
      * Resolve ${VAR_NAME} placeholders.
      */
-    private static function resolvePlaceholders(string $value): string
+    private static function resolvePlaceholders(string $value, int $depth = 0): string
     {
-        return preg_replace_callback('/\$\{([^}]+)\}/', function ($m) {
-            return self::get($m[1], '');
+        if ($depth > 10) {
+            return $value;
+        }
+        return preg_replace_callback('/\$\{([^}]+)\}/', function ($m) use ($depth) {
+            return self::resolvePlaceholders(self::get($m[1], ''), $depth + 1);
         }, $value);
     }
 

--- a/sdf/core/Env.php
+++ b/sdf/core/Env.php
@@ -1,0 +1,175 @@
+<?php
+
+/**
+ * smskSoft SDF Environment
+ * Copyright devsimsek
+ * @package     SDF
+ * @subpackage  SDF Core
+ * @file        Env.php
+ * @version     v1.0.0
+ * @author      devsimsek
+ * @copyright   Copyright (c) 2025, smskSoft, devsimsek
+ * @license     https://opensource.org/licenses/MIT	MIT License
+ * @link        https://github.com/devsimsek/project-sdf/wiki/libraries/env
+ * @since       Version 2.2
+ * @filesource
+ */
+
+namespace SDF;
+
+/**
+ * Lightweight .env loader.
+ *
+ * Loads KEY=VALUE pairs from a .env file and sets them via putenv() + $_ENV.
+ * Supports quoted values, inline comments (#), and blank lines.
+ *
+ * Usage:
+ *   Env::load(__DIR__ . '/../.env');
+ *   $dbHost = Env::get('DB_HOST', 'localhost');
+ */
+class Env
+{
+    /** @var array<string, string> Loaded variables. */
+    private static array $vars = [];
+
+    /**
+     * Load a .env file.
+     *
+     * @param string $path Absolute path to .env file.
+     * @return void
+     */
+    public static function load(string $path): void
+    {
+        if (!is_file($path)) {
+            return;
+        }
+
+        $lines = file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+        if ($lines === false) {
+            return;
+        }
+
+        foreach ($lines as $line) {
+            $line = trim($line);
+
+            if ($line === '' || str_starts_with($line, '#')) {
+                continue;
+            }
+
+            $eqPos = strpos($line, '=');
+            if ($eqPos === false) {
+                continue;
+            }
+
+            $key = trim(substr($line, 0, $eqPos));
+            $value = trim(substr($line, $eqPos + 1));
+
+            $value = self::stripComments($value);
+            $value = self::unquote($value);
+            $value = self::resolvePlaceholders($value);
+
+            if ($key !== '') {
+                self::set($key, $value);
+            }
+        }
+    }
+
+    /**
+     * Get an environment variable.
+     *
+     * @param string     $key     Variable name.
+     * @param mixed|null $default Fallback when not set.
+     * @return mixed
+     */
+    public static function get(string $key, mixed $default = null): mixed
+    {
+        if (array_key_exists($key, self::$vars)) {
+            return self::$vars[$key];
+        }
+        $env = getenv($key);
+        if ($env !== false) {
+            return $env;
+        }
+        return $default;
+    }
+
+    /**
+     * Set a variable at runtime.
+     *
+     * @param string $key
+     * @param string $value
+     * @return void
+     */
+    public static function set(string $key, string $value): void
+    {
+        self::$vars[$key] = $value;
+        putenv("$key=$value");
+        $_ENV[$key] = $value;
+    }
+
+    /**
+     * Check if a variable exists.
+     *
+     * @param string $key
+     * @return bool
+     */
+    public static function has(string $key): bool
+    {
+        return array_key_exists($key, self::$vars) || getenv($key) !== false;
+    }
+
+    /**
+     * Strip trailing inline comments (#), respecting single/double quotes.
+     */
+    private static function stripComments(string $value): string
+    {
+        $inSingle = false;
+        $inDouble = false;
+        $len = strlen($value);
+        for ($i = 0; $i < $len; $i++) {
+            $ch = $value[$i];
+            if ($ch === "'" && !$inDouble) {
+                $inSingle = !$inSingle;
+            } elseif ($ch === '"' && !$inSingle) {
+                $inDouble = !$inDouble;
+            } elseif ($ch === '#' && !$inSingle && !$inDouble) {
+                return trim(substr($value, 0, $i));
+            }
+        }
+        return $value;
+    }
+
+    /**
+     * Remove matching surrounding quotes.
+     */
+    private static function unquote(string $value): string
+    {
+        $first = $value[0] ?? '';
+        $last = $value[-1] ?? '';
+
+        if (($first === '"' && $last === '"') || ($first === "'" && $last === "'")) {
+            return substr($value, 1, -1);
+        }
+        return $value;
+    }
+
+    /**
+     * Resolve ${VAR_NAME} placeholders.
+     */
+    private static function resolvePlaceholders(string $value): string
+    {
+        return preg_replace_callback('/\$\{([^}]+)\}/', function ($m) {
+            return self::get($m[1], '');
+        }, $value);
+    }
+
+    /**
+     * Reset loaded variables (for testing).
+     *
+     * @return void
+     */
+    public static function reset(): void
+    {
+        self::$vars = [];
+    }
+}

--- a/sdf/core/Env.php
+++ b/sdf/core/Env.php
@@ -144,8 +144,13 @@ class Env
      */
     private static function unquote(string $value): string
     {
-        $first = $value[0] ?? '';
-        $last = $value[-1] ?? '';
+        $len = strlen($value);
+        if ($len < 2) {
+            return $value;
+        }
+
+        $first = $value[0];
+        $last = $value[$len - 1];
 
         if (($first === '"' && $last === '"') || ($first === "'" && $last === "'")) {
             return substr($value, 1, -1);

--- a/sdf/core/Flash.php
+++ b/sdf/core/Flash.php
@@ -45,7 +45,9 @@ class Flash
      */
     public function set(string $key, mixed $value): self
     {
-        $_SESSION[self::NEW_KEY][$key] = $value;
+        $bucket = $this->session->get(self::NEW_KEY, []);
+        $bucket[$key] = $value;
+        $this->session->set(self::NEW_KEY, $bucket);
         return $this;
     }
 
@@ -58,9 +60,11 @@ class Flash
      */
     public function get(string $key, mixed $default = null): mixed
     {
-        if (isset($_SESSION[self::CUR_KEY][$key])) {
-            $value = $_SESSION[self::CUR_KEY][$key];
-            unset($_SESSION[self::CUR_KEY][$key]);
+        $bucket = $this->session->get(self::CUR_KEY, []);
+        if (array_key_exists($key, $bucket)) {
+            $value = $bucket[$key];
+            unset($bucket[$key]);
+            $this->session->set(self::CUR_KEY, $bucket);
             return $value;
         }
 
@@ -75,8 +79,9 @@ class Flash
      */
     public function has(string $key): bool
     {
-        return isset($_SESSION[self::CUR_KEY][$key])
-            || isset($_SESSION[self::NEW_KEY][$key]);
+        $new = $this->session->get(self::NEW_KEY, []);
+        $cur = $this->session->get(self::CUR_KEY, []);
+        return isset($cur[$key]) || isset($new[$key]);
     }
 
     /**
@@ -87,8 +92,8 @@ class Flash
     public function all(): array
     {
         return array_merge(
-            $_SESSION[self::NEW_KEY] ?? [],
-            $_SESSION[self::CUR_KEY] ?? [],
+            $this->session->get(self::NEW_KEY, []),
+            $this->session->get(self::CUR_KEY, []),
         );
     }
 
@@ -100,9 +105,13 @@ class Flash
      */
     public function keep(string $key): self
     {
-        if (isset($_SESSION[self::CUR_KEY][$key])) {
-            $_SESSION[self::NEW_KEY][$key] = $_SESSION[self::CUR_KEY][$key];
-            unset($_SESSION[self::CUR_KEY][$key]);
+        $cur = $this->session->get(self::CUR_KEY, []);
+        if (isset($cur[$key])) {
+            $new = $this->session->get(self::NEW_KEY, []);
+            $new[$key] = $cur[$key];
+            $this->session->set(self::NEW_KEY, $new);
+            unset($cur[$key]);
+            $this->session->set(self::CUR_KEY, $cur);
         }
 
         return $this;
@@ -117,7 +126,9 @@ class Flash
      */
     public function now(string $key, mixed $value): self
     {
-        $_SESSION[self::CUR_KEY][$key] = $value;
+        $bucket = $this->session->get(self::CUR_KEY, []);
+        $bucket[$key] = $value;
+        $this->session->set(self::CUR_KEY, $bucket);
         return $this;
     }
 
@@ -141,13 +152,15 @@ class Flash
      */
     private function age(): void
     {
-        if (isset($_SESSION[self::CUR_KEY])) {
-            unset($_SESSION[self::CUR_KEY]);
+        $cur = $this->session->get(self::CUR_KEY);
+        if ($cur !== null) {
+            $this->session->remove(self::CUR_KEY);
         }
 
-        if (isset($_SESSION[self::NEW_KEY])) {
-            $_SESSION[self::CUR_KEY] = $_SESSION[self::NEW_KEY];
-            unset($_SESSION[self::NEW_KEY]);
+        $new = $this->session->get(self::NEW_KEY);
+        if ($new !== null) {
+            $this->session->set(self::CUR_KEY, $new);
+            $this->session->remove(self::NEW_KEY);
         }
     }
 }

--- a/sdf/core/Flash.php
+++ b/sdf/core/Flash.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace SDF;
+
+/**
+ * Project SDF Flash Messages
+ * Copyright devsimsek
+ * @package     SDF
+ * @subpackage  SDF Core
+ * @file        Flash.php
+ * @version     v2.0.0
+ * @author      devsimsek
+ * @copyright   Copyright (c) 2025, smskSoft, devsimsek
+ * @license     https://opensource.org/licenses/MIT	MIT License
+ * @link        https://github.com/devsimsek/project-sdf/wiki/libraries/flash
+ * @since       Version 2.0
+ * @filesource
+ */
+class Flash
+{
+    /** @var string Session key for new (next-request) flash messages */
+    private const NEW_KEY = '_sdf_flash_new';
+
+    /** @var string Session key for current-request flash messages */
+    private const CUR_KEY = '_sdf_flash_cur';
+
+    /** @var Session Backing session store */
+    private Session $session;
+
+    /**
+     * @param Session|null $session Optional session instance; defaults to singleton.
+     */
+    public function __construct(?Session $session = null)
+    {
+        $this->session = $session ?? Session::getInstance();
+        $this->age();
+    }
+
+    /**
+     * Set a flash message for the next request.
+     *
+     * @param string $key   Message key.
+     * @param mixed  $value Message value.
+     * @return $this
+     */
+    public function set(string $key, mixed $value): self
+    {
+        $_SESSION[self::NEW_KEY][$key] = $value;
+        return $this;
+    }
+
+    /**
+     * Retrieve a flash message (consumes it).
+     *
+     * @param string $key     Message key.
+     * @param mixed  $default Default value if key does not exist.
+     * @return mixed
+     */
+    public function get(string $key, mixed $default = null): mixed
+    {
+        if (isset($_SESSION[self::CUR_KEY][$key])) {
+            $value = $_SESSION[self::CUR_KEY][$key];
+            unset($_SESSION[self::CUR_KEY][$key]);
+            return $value;
+        }
+
+        return $default;
+    }
+
+    /**
+     * Check if a flash message exists (does not consume).
+     *
+     * @param string $key Message key.
+     * @return bool
+     */
+    public function has(string $key): bool
+    {
+        return isset($_SESSION[self::CUR_KEY][$key])
+            || isset($_SESSION[self::NEW_KEY][$key]);
+    }
+
+    /**
+     * Return all flash messages without consuming them.
+     *
+     * @return array<string, mixed>
+     */
+    public function all(): array
+    {
+        return array_merge(
+            $_SESSION[self::NEW_KEY] ?? [],
+            $_SESSION[self::CUR_KEY] ?? [],
+        );
+    }
+
+    /**
+     * Keep a flash message for one more request.
+     *
+     * @param string $key Message key.
+     * @return $this
+     */
+    public function keep(string $key): self
+    {
+        if (isset($_SESSION[self::CUR_KEY][$key])) {
+            $_SESSION[self::NEW_KEY][$key] = $_SESSION[self::CUR_KEY][$key];
+            unset($_SESSION[self::CUR_KEY][$key]);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Set a flash message available immediately (does not persist).
+     *
+     * @param string $key   Message key.
+     * @param mixed  $value Message value.
+     * @return $this
+     */
+    public function now(string $key, mixed $value): self
+    {
+        $_SESSION[self::CUR_KEY][$key] = $value;
+        return $this;
+    }
+
+    /**
+     * Alias for set().
+     *
+     * @param string $key   Message key.
+     * @param mixed  $value Message value.
+     * @return $this
+     */
+    public function flash(string $key, mixed $value): self
+    {
+        return $this->set($key, $value);
+    }
+
+    /**
+     * Age flash data: discard current-request messages and promote
+     * next-request messages to the current request.
+     *
+     * @return void
+     */
+    private function age(): void
+    {
+        if (isset($_SESSION[self::CUR_KEY])) {
+            unset($_SESSION[self::CUR_KEY]);
+        }
+
+        if (isset($_SESSION[self::NEW_KEY])) {
+            $_SESSION[self::CUR_KEY] = $_SESSION[self::NEW_KEY];
+            unset($_SESSION[self::NEW_KEY]);
+        }
+    }
+}

--- a/sdf/core/Http/Response.php
+++ b/sdf/core/Http/Response.php
@@ -1,0 +1,330 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SDF\Http;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+
+/**
+ * smskSoft SDF PSR-7 Response
+ * Copyright devsimsek
+ * @package     SDF
+ * @subpackage  SDF\Http
+ * @file        Response.php
+ * @version     v1.0.0
+ * @author      devsimsek
+ * @copyright   Copyright (c) 2025, smskSoft, devsimsek
+ * @license     https://opensource.org/licenses/MIT	MIT License
+ * @url         https://github.com/devsimsek/project-sdf/wiki/libraries/http.md
+ * @since       Version 2.0
+ * @filesource
+ */
+class Response implements ResponseInterface
+{
+    /** @var string Protocol version (e.g. '1.1', '2.0'). */
+    private string $protocolVersion = '1.1';
+
+    /** @var array<string, string[]> Headers mapped by original name. */
+    private array $headers = [];
+
+    /** @var array<string, string> Lowercased name to original header name. */
+    private array $headerNames = [];
+
+    /** @var StreamInterface Message body. */
+    private StreamInterface $body;
+
+    /** @var int HTTP status code. */
+    private int $statusCode;
+
+    /** @var string HTTP reason phrase. */
+    private string $reasonPhrase = '';
+
+    /** @var array<int, string> Default reason phrases per HTTP status code. */
+    private const PHRASES = [
+        100 => 'Continue',
+        101 => 'Switching Protocols',
+        200 => 'OK',
+        201 => 'Created',
+        202 => 'Accepted',
+        203 => 'Non-Authoritative Information',
+        204 => 'No Content',
+        205 => 'Reset Content',
+        206 => 'Partial Content',
+        300 => 'Multiple Choices',
+        301 => 'Moved Permanently',
+        302 => 'Found',
+        303 => 'See Other',
+        304 => 'Not Modified',
+        305 => 'Use Proxy',
+        307 => 'Temporary Redirect',
+        308 => 'Permanent Redirect',
+        400 => 'Bad Request',
+        401 => 'Unauthorized',
+        402 => 'Payment Required',
+        403 => 'Forbidden',
+        404 => 'Not Found',
+        405 => 'Method Not Allowed',
+        406 => 'Not Acceptable',
+        407 => 'Proxy Authentication Required',
+        408 => 'Request Timeout',
+        409 => 'Conflict',
+        410 => 'Gone',
+        411 => 'Length Required',
+        412 => 'Precondition Failed',
+        413 => 'Content Too Large',
+        414 => 'URI Too Long',
+        415 => 'Unsupported Media Type',
+        416 => 'Range Not Satisfiable',
+        417 => 'Expectation Failed',
+        426 => 'Upgrade Required',
+        429 => 'Too Many Requests',
+        500 => 'Internal Server Error',
+        501 => 'Not Implemented',
+        502 => 'Bad Gateway',
+        503 => 'Service Unavailable',
+        504 => 'Gateway Timeout',
+        505 => 'HTTP Version Not Supported',
+    ];
+
+    /**
+     * @param int                        $status  HTTP status code.
+     * @param array<string, string|string[]> $headers Response headers.
+     * @param StreamInterface|string|null $body    Response body.
+     * @param string                     $version HTTP protocol version.
+     * @param string|null                $reason  Reason phrase (auto-resolved when null).
+     */
+    public function __construct(
+        int $status = 200,
+        array $headers = [],
+        StreamInterface|string|null $body = null,
+        string $version = '1.1',
+        ?string $reason = null,
+    ) {
+        $this->statusCode = $status;
+        $this->protocolVersion = $version;
+        $this->reasonPhrase = $reason ?? (self::PHRASES[$status] ?? '');
+
+        if ($body === null) {
+            $body = new Stream('', 'r');
+        } elseif (is_string($body)) {
+            $body = new Stream($body, 'r');
+        }
+
+        $this->body = $body;
+
+        foreach ($headers as $name => $value) {
+            $this->setHeader($name, $value);
+        }
+    }
+
+    /**
+     * Get the HTTP protocol version.
+     *
+     * @return string
+     */
+    public function getProtocolVersion(): string
+    {
+        return $this->protocolVersion;
+    }
+
+    /**
+     * Return an instance with the specified protocol version.
+     *
+     * @param string $version
+     *
+     * @return static
+     */
+    public function withProtocolVersion(string $version): static
+    {
+        $new = clone $this;
+        $new->protocolVersion = $version;
+        return $new;
+    }
+
+    /**
+     * Get all message headers.
+     *
+     * @return array<string, string[]>
+     */
+    public function getHeaders(): array
+    {
+        return $this->headers;
+    }
+
+    /**
+     * Check if a header exists.
+     *
+     * @param string $name
+     *
+     * @return bool
+     */
+    public function hasHeader(string $name): bool
+    {
+        return isset($this->headerNames[strtolower($name)]);
+    }
+
+    /**
+     * Get a header by name (array of values).
+     *
+     * @param string $name
+     *
+     * @return string[]
+     */
+    public function getHeader(string $name): array
+    {
+        $lower = strtolower($name);
+
+        if (!isset($this->headerNames[$lower])) {
+            return [];
+        }
+
+        $actual = $this->headerNames[$lower];
+        return $this->headers[$actual];
+    }
+
+    /**
+     * Get a comma-separated header line.
+     *
+     * @param string $name
+     *
+     * @return string
+     */
+    public function getHeaderLine(string $name): string
+    {
+        $values = $this->getHeader($name);
+        return implode(', ', $values);
+    }
+
+    /**
+     * Return an instance with the specified header.
+     *
+     * @param string          $name
+     * @param string|string[] $value
+     *
+     * @return static
+     */
+    public function withHeader(string $name, $value): static
+    {
+        $new = clone $this;
+        $new->setHeader($name, $value);
+        return $new;
+    }
+
+    /**
+     * Return an instance with an additional header value.
+     *
+     * @param string          $name
+     * @param string|string[] $value
+     *
+     * @return static
+     */
+    public function withAddedHeader(string $name, $value): static
+    {
+        $new = clone $this;
+        $values = $new->getHeader($name);
+        $values = array_merge($values, (array) $value);
+        $new->setHeader($name, $values);
+        return $new;
+    }
+
+    /**
+     * Return an instance without the specified header.
+     *
+     * @param string $name
+     *
+     * @return static
+     */
+    public function withoutHeader(string $name): static
+    {
+        $lower = strtolower($name);
+
+        if (!isset($this->headerNames[$lower])) {
+            return clone $this;
+        }
+
+        $new = clone $this;
+        $actual = $new->headerNames[$lower];
+        unset($new->headers[$actual], $new->headerNames[$lower]);
+        return $new;
+    }
+
+    /**
+     * Get the message body.
+     *
+     * @return StreamInterface
+     */
+    public function getBody(): StreamInterface
+    {
+        return $this->body;
+    }
+
+    /**
+     * Return an instance with the specified body.
+     *
+     * @param StreamInterface $body
+     *
+     * @return static
+     */
+    public function withBody(StreamInterface $body): static
+    {
+        $new = clone $this;
+        $new->body = $body;
+        return $new;
+    }
+
+    /**
+     * Get the HTTP status code.
+     *
+     * @return int
+     */
+    public function getStatusCode(): int
+    {
+        return $this->statusCode;
+    }
+
+    /**
+     * Return an instance with the specified status code and reason phrase.
+     *
+     * @param int    $code
+     * @param string $reasonPhrase
+     *
+     * @return static
+     */
+    public function withStatus(int $code, string $reasonPhrase = ''): static
+    {
+        $new = clone $this;
+        $new->statusCode = $code;
+        $new->reasonPhrase = $reasonPhrase !== ''
+            ? $reasonPhrase
+            : (self::PHRASES[$code] ?? '');
+        return $new;
+    }
+
+    /**
+     * Get the HTTP reason phrase.
+     *
+     * @return string
+     */
+    public function getReasonPhrase(): string
+    {
+        return $this->reasonPhrase;
+    }
+
+    /**
+     * Internal helper to register a header maintaining casing.
+     *
+     * @param string          $name
+     * @param string|string[] $values
+     *
+     * @return void
+     */
+    private function setHeader(string $name, array|string $values): void
+    {
+        $values = is_array($values) ? $values : [$values];
+        $lower = strtolower($name);
+        $this->headerNames[$lower] = $name;
+        $this->headers[$name] = $values;
+    }
+}

--- a/sdf/core/Http/ServerRequest.php
+++ b/sdf/core/Http/ServerRequest.php
@@ -1,0 +1,658 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SDF\Http;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UriInterface;
+use RuntimeException;
+
+/**
+ * smskSoft SDF PSR-7 ServerRequest
+ * Copyright devsimsek
+ * @package     SDF
+ * @subpackage  SDF\Http
+ * @file        ServerRequest.php
+ * @version     v1.0.0
+ * @author      devsimsek
+ * @copyright   Copyright (c) 2025, smskSoft, devsimsek
+ * @license     https://opensource.org/licenses/MIT	MIT License
+ * @url         https://github.com/devsimsek/project-sdf/wiki/libraries/http.md
+ * @since       Version 2.0
+ * @filesource
+ */
+class ServerRequest implements ServerRequestInterface
+{
+    /** @var string HTTP protocol version. */
+    private string $protocolVersion = '1.1';
+
+    /** @var array<string, string[]> Headers mapped by original name. */
+    private array $headers = [];
+
+    /** @var array<string, string> Lowercased name to original header name. */
+    private array $headerNames = [];
+
+    /** @var StreamInterface Request body. */
+    private StreamInterface $body;
+
+    /** @var string HTTP method (uppercased). */
+    private string $method = 'GET';
+
+    /** @var UriInterface Request URI. */
+    private UriInterface $uri;
+
+    /** @var string Custom request target (empty to auto-resolve). */
+    private string $requestTarget = '';
+
+    /** @var array Server parameters ($_SERVER). */
+    private array $serverParams = [];
+
+    /** @var array Cookie parameters ($_COOKIE). */
+    private array $cookieParams = [];
+
+    /** @var array Query parameters ($_GET). */
+    private array $queryParams = [];
+
+    /** @var array<string, \Psr\Http\Message\UploadedFileInterface> Uploaded files. */
+    private array $uploadedFiles = [];
+
+    /** @var array|object|null Parsed body. */
+    private null|array|object $parsedBody = null;
+
+    /** @var array<string, mixed> Custom attributes. */
+    private array $attributes = [];
+
+    /**
+     * @param string                        $method        HTTP method.
+     * @param string|UriInterface           $uri           Request URI.
+     * @param array<string, string|string[]> $headers      Request headers.
+     * @param StreamInterface|string|null   $body          Request body.
+     * @param string                        $version       HTTP protocol version.
+     * @param array                         $serverParams  $_SERVER-like parameters.
+     */
+    public function __construct(
+        string $method = 'GET',
+        string|UriInterface $uri = '',
+        array $headers = [],
+        StreamInterface|string|null $body = null,
+        string $version = '1.1',
+        array $serverParams = [],
+    ) {
+        $this->method = strtoupper($method);
+        $this->protocolVersion = $version;
+        $this->serverParams = $serverParams;
+
+        $this->uri = $uri instanceof UriInterface ? $uri : new Uri($uri);
+
+        if ($body === null) {
+            $body = new Stream('', 'r');
+        } elseif (is_string($body)) {
+            $body = new Stream($body, 'r');
+        }
+
+        $this->body = $body;
+
+        foreach ($headers as $name => $value) {
+            $this->setHeader($name, $value);
+        }
+    }
+
+    /**
+     * Create a ServerRequest from PHP superglobals.
+     *
+     * @return self
+     *
+     * @throws RuntimeException When unable to open php://input.
+     */
+    public static function fromGlobals(): self
+    {
+        $method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+        $uri = new Uri(
+            (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off' ? 'https' : 'http')
+            . '://'
+            . ($_SERVER['HTTP_HOST'] ?? 'localhost')
+            . ($_SERVER['REQUEST_URI'] ?? '/'),
+        );
+
+        $headers = [];
+        if (function_exists('getallheaders')) {
+            $headers = getallheaders() ?: [];
+        }
+
+        $inputStream = fopen('php://input', 'r');
+        if ($inputStream === false) {
+            throw new RuntimeException('Unable to open php://input');
+        }
+        $body = new Stream($inputStream);
+
+        $parsedBody = null;
+        $contentType = $headers['Content-Type'] ?? $headers['content-type'] ?? '';
+        if (str_contains($contentType, 'application/json') || str_contains($contentType, 'application/x-json')) {
+            $rawBody = $body->__toString();
+            if ($rawBody !== '') {
+                $parsedBody = json_decode($rawBody, false);
+                $body->rewind();
+            }
+        } elseif ($method === 'POST') {
+            $parsedBody = $_POST;
+        }
+
+        $uploadedFiles = self::parseUploadedFiles($_FILES);
+
+        $serverProtocol = $_SERVER['SERVER_PROTOCOL'] ?? 'HTTP/1.1';
+        $version = $serverProtocol === 'HTTP/1.1' ? '1.1' : '1.0';
+
+        $request = new self(
+            $method,
+            $uri,
+            $headers,
+            $body,
+            $version,
+            $_SERVER,
+        );
+
+        $request->queryParams = $_GET;
+        $request->cookieParams = $_COOKIE;
+        $request->parsedBody = $parsedBody;
+        $request->uploadedFiles = $uploadedFiles;
+
+        return $request;
+    }
+
+    /**
+     * Get the HTTP protocol version.
+     *
+     * @return string
+     */
+    public function getProtocolVersion(): string
+    {
+        return $this->protocolVersion;
+    }
+
+    /**
+     * Return an instance with the specified protocol version.
+     *
+     * @param string $version
+     *
+     * @return static
+     */
+    public function withProtocolVersion(string $version): static
+    {
+        $new = clone $this;
+        $new->protocolVersion = $version;
+        return $new;
+    }
+
+    /**
+     * Get all message headers.
+     *
+     * @return array<string, string[]>
+     */
+    public function getHeaders(): array
+    {
+        return $this->headers;
+    }
+
+    /**
+     * Check if a header exists.
+     *
+     * @param string $name
+     *
+     * @return bool
+     */
+    public function hasHeader(string $name): bool
+    {
+        return isset($this->headerNames[strtolower($name)]);
+    }
+
+    /**
+     * Get a header by name (array of values).
+     *
+     * @param string $name
+     *
+     * @return string[]
+     */
+    public function getHeader(string $name): array
+    {
+        $lower = strtolower($name);
+
+        if (!isset($this->headerNames[$lower])) {
+            return [];
+        }
+
+        $actual = $this->headerNames[$lower];
+        return $this->headers[$actual];
+    }
+
+    /**
+     * Get a comma-separated header line.
+     *
+     * @param string $name
+     *
+     * @return string
+     */
+    public function getHeaderLine(string $name): string
+    {
+        return implode(', ', $this->getHeader($name));
+    }
+
+    /**
+     * Return an instance with the specified header.
+     *
+     * @param string          $name
+     * @param string|string[] $value
+     *
+     * @return static
+     */
+    public function withHeader(string $name, $value): static
+    {
+        $new = clone $this;
+        $new->setHeader($name, $value);
+        return $new;
+    }
+
+    /**
+     * Return an instance with an additional header value.
+     *
+     * @param string          $name
+     * @param string|string[] $value
+     *
+     * @return static
+     */
+    public function withAddedHeader(string $name, $value): static
+    {
+        $new = clone $this;
+        $values = $new->getHeader($name);
+        $values = array_merge($values, (array) $value);
+        $new->setHeader($name, $values);
+        return $new;
+    }
+
+    /**
+     * Return an instance without the specified header.
+     *
+     * @param string $name
+     *
+     * @return static
+     */
+    public function withoutHeader(string $name): static
+    {
+        $lower = strtolower($name);
+
+        if (!isset($this->headerNames[$lower])) {
+            return clone $this;
+        }
+
+        $new = clone $this;
+        $actual = $new->headerNames[$lower];
+        unset($new->headers[$actual], $new->headerNames[$lower]);
+        return $new;
+    }
+
+    /**
+     * Get the message body.
+     *
+     * @return StreamInterface
+     */
+    public function getBody(): StreamInterface
+    {
+        return $this->body;
+    }
+
+    /**
+     * Return an instance with the specified body.
+     *
+     * @param StreamInterface $body
+     *
+     * @return static
+     */
+    public function withBody(StreamInterface $body): static
+    {
+        $new = clone $this;
+        $new->body = $body;
+        return $new;
+    }
+
+    /**
+     * Get the request target (path + query).
+     *
+     * @return string
+     */
+    public function getRequestTarget(): string
+    {
+        if ($this->requestTarget !== '') {
+            return $this->requestTarget;
+        }
+
+        $target = $this->uri->getPath();
+        if ($target === '') {
+            $target = '/';
+        }
+
+        $query = $this->uri->getQuery();
+        if ($query !== '') {
+            $target .= '?' . $query;
+        }
+
+        return $target;
+    }
+
+    /**
+     * Return an instance with the specified request target.
+     *
+     * @param string $requestTarget
+     *
+     * @return static
+     */
+    public function withRequestTarget(string $requestTarget): static
+    {
+        $new = clone $this;
+        $new->requestTarget = $requestTarget;
+        return $new;
+    }
+
+    /**
+     * Get the HTTP method.
+     *
+     * @return string
+     */
+    public function getMethod(): string
+    {
+        return $this->method;
+    }
+
+    /**
+     * Return an instance with the specified HTTP method.
+     *
+     * @param string $method
+     *
+     * @return static
+     */
+    public function withMethod(string $method): static
+    {
+        $new = clone $this;
+        $new->method = strtoupper($method);
+        return $new;
+    }
+
+    /**
+     * Get the request URI.
+     *
+     * @return UriInterface
+     */
+    public function getUri(): UriInterface
+    {
+        return $this->uri;
+    }
+
+    /**
+     * Return an instance with the specified URI, optionally preserving the Host header.
+     *
+     * @param UriInterface $uri
+     * @param bool         $preserveHost
+     *
+     * @return static
+     */
+    public function withUri(UriInterface $uri, bool $preserveHost = false): static
+    {
+        $new = clone $this;
+        $new->uri = $uri;
+
+        if (!$preserveHost || !$this->hasHeader('Host')) {
+            $host = $uri->getHost();
+            if ($host !== '') {
+                $port = $uri->getPort();
+                $host .= $port !== null ? ':' . $port : '';
+                $new->setHeader('Host', $host);
+            }
+        }
+
+        return $new;
+    }
+
+    /**
+     * Get the server parameters.
+     *
+     * @return array
+     */
+    public function getServerParams(): array
+    {
+        return $this->serverParams;
+    }
+
+    /**
+     * Get the cookie parameters.
+     *
+     * @return array<string, string>
+     */
+    public function getCookieParams(): array
+    {
+        return $this->cookieParams;
+    }
+
+    /**
+     * Return an instance with the specified cookie parameters.
+     *
+     * @param array<string, string> $cookies
+     *
+     * @return static
+     */
+    public function withCookieParams(array $cookies): static
+    {
+        $new = clone $this;
+        $new->cookieParams = $cookies;
+        return $new;
+    }
+
+    /**
+     * Get the query parameters.
+     *
+     * @return array<string, string>
+     */
+    public function getQueryParams(): array
+    {
+        return $this->queryParams;
+    }
+
+    /**
+     * Return an instance with the specified query parameters.
+     *
+     * @param array $query
+     *
+     * @return static
+     */
+    public function withQueryParams(array $query): static
+    {
+        $new = clone $this;
+        $new->queryParams = $query;
+        return $new;
+    }
+
+    /**
+     * Get the uploaded files.
+     *
+     * @return array<string, \Psr\Http\Message\UploadedFileInterface>
+     */
+    public function getUploadedFiles(): array
+    {
+        return $this->uploadedFiles;
+    }
+
+    /**
+     * Return an instance with the specified uploaded files.
+     *
+     * @param array $uploadedFiles
+     *
+     * @return static
+     */
+    public function withUploadedFiles(array $uploadedFiles): static
+    {
+        $new = clone $this;
+        $new->uploadedFiles = $uploadedFiles;
+        return $new;
+    }
+
+    /**
+     * Get the parsed body.
+     *
+     * @return array|object|null
+     */
+    public function getParsedBody(): null|array|object
+    {
+        return $this->parsedBody;
+    }
+
+    /**
+     * Return an instance with the specified parsed body.
+     *
+     * @param array|object|null $data
+     *
+     * @return static
+     */
+    public function withParsedBody($data): static
+    {
+        $new = clone $this;
+        $new->parsedBody = $data;
+        return $new;
+    }
+
+    /**
+     * Get all custom attributes.
+     *
+     * @return array<string, mixed>
+     */
+    public function getAttributes(): array
+    {
+        return $this->attributes;
+    }
+
+    /**
+     * Get a single custom attribute.
+     *
+     * @param string $name
+     * @param mixed  $default
+     *
+     * @return mixed
+     */
+    public function getAttribute(string $name, mixed $default = null): mixed
+    {
+        return array_key_exists($name, $this->attributes)
+            ? $this->attributes[$name]
+            : $default;
+    }
+
+    /**
+     * Return an instance with the specified attribute.
+     *
+     * @param string $name
+     * @param mixed  $value
+     *
+     * @return static
+     */
+    public function withAttribute(string $name, $value): static
+    {
+        $new = clone $this;
+        $new->attributes[$name] = $value;
+        return $new;
+    }
+
+    /**
+     * Return an instance without the specified attribute.
+     *
+     * @param string $name
+     *
+     * @return static
+     */
+    public function withoutAttribute(string $name): static
+    {
+        if (!array_key_exists($name, $this->attributes)) {
+            return clone $this;
+        }
+
+        $new = clone $this;
+        unset($new->attributes[$name]);
+        return $new;
+    }
+
+    /**
+     * Internal helper to register a header maintaining casing.
+     *
+     * @param string          $name
+     * @param string|string[] $values
+     *
+     * @return void
+     */
+    private function setHeader(string $name, array|string $values): void
+    {
+        $values = is_array($values) ? $values : [$values];
+        $lower = strtolower($name);
+        $this->headerNames[$lower] = $name;
+        $this->headers[$name] = $values;
+    }
+
+    /**
+     * Parse $_FILES into a structured array of UploadedFile instances.
+     *
+     * @param array $files $_FILES superglobal.
+     *
+     * @return array<string, \Psr\Http\Message\UploadedFileInterface>
+     */
+    private static function parseUploadedFiles(array $files): array
+    {
+        $result = [];
+
+        foreach ($files as $key => $spec) {
+            if (is_array($spec['error'] ?? null)) {
+                $result[$key] = self::parseNestedFiles($spec);
+            } elseif (isset($spec['tmp_name'])) {
+                $result[$key] = new UploadedFile(
+                    $spec['tmp_name'],
+                    $spec['error'] ?? UPLOAD_ERR_NO_FILE,
+                    $spec['name'] ?? null,
+                    $spec['type'] ?? null,
+                    $spec['size'] ?? null,
+                );
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Recursively parse a nested $_FILES array (multi-file uploads).
+     *
+     * @param array $spec A single entry from $_FILES.
+     *
+     * @return array
+     */
+    private static function parseNestedFiles(array $spec): array
+    {
+        $result = [];
+        $files = $spec['name'] ?? [];
+
+        foreach ($files as $index => $name) {
+            $error = $spec['error'][$index] ?? UPLOAD_ERR_NO_FILE;
+            if (is_array($name)) {
+                $result[$index] = self::parseNestedFiles([
+                    'name' => $spec['name'][$index],
+                    'type' => $spec['type'][$index] ?? [],
+                    'tmp_name' => $spec['tmp_name'][$index] ?? [],
+                    'error' => $spec['error'][$index] ?? [],
+                    'size' => $spec['size'][$index] ?? [],
+                ]);
+            } else {
+                $result[$index] = new UploadedFile(
+                    $spec['tmp_name'][$index] ?? '',
+                    $error,
+                    $name,
+                    $spec['type'][$index] ?? null,
+                    $spec['size'][$index] ?? null,
+                );
+            }
+        }
+
+        return $result;
+    }
+}

--- a/sdf/core/Http/Stream.php
+++ b/sdf/core/Http/Stream.php
@@ -1,0 +1,358 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SDF\Http;
+
+use Psr\Http\Message\StreamInterface;
+use RuntimeException;
+
+/**
+ * smskSoft SDF PSR-7 Stream
+ * Copyright devsimsek
+ * @package     SDF
+ * @subpackage  SDF\Http
+ * @file        Stream.php
+ * @version     v1.0.0
+ * @author      devsimsek
+ * @copyright   Copyright (c) 2025, smskSoft, devsimsek
+ * @license     https://opensource.org/licenses/MIT	MIT License
+ * @url         https://github.com/devsimsek/project-sdf/wiki/libraries/http.md
+ * @since       Version 2.0
+ * @filesource
+ */
+class Stream implements StreamInterface
+{
+    /** @var resource|null Underlying stream resource. */
+    private $stream = null;
+
+    /** @var bool Whether the stream is seekable. */
+    private bool $seekable;
+
+    /** @var bool Whether the stream is readable. */
+    private bool $readable;
+
+    /** @var bool Whether the stream is writable. */
+    private bool $writable;
+
+    /** @var array<string, mixed>|null Cached stream metadata. */
+    private ?array $metadata = null;
+
+    /** @var int|null Cached size in bytes. */
+    private ?int $size = null;
+
+    /**
+     * @param resource|string $body  Stream resource or string content.
+     * @param string          $mode  Stream open mode (used when $body is a resource).
+     *
+     * @throws RuntimeException When unable to open php://temp.
+     * @throws \InvalidArgumentException When body is not a string or resource.
+     */
+    public function __construct(mixed $body = '', string $mode = 'r')
+    {
+        if (is_string($body)) {
+            $resource = fopen('php://temp', 'r+');
+            if ($resource === false) {
+                throw new RuntimeException('Unable to open php://temp');
+            }
+            fwrite($resource, $body);
+            rewind($resource);
+            $this->stream = $resource;
+        } elseif (is_resource($body)) {
+            $this->stream = $body;
+        } else {
+            throw new \InvalidArgumentException(
+                'Stream body must be a string or resource',
+            );
+        }
+
+        $this->setMetadata();
+    }
+
+    /**
+     * Read entire stream contents.
+     *
+     * @return string
+     */
+    public function __toString(): string
+    {
+        if (!$this->stream) {
+            return '';
+        }
+
+        try {
+            $this->rewind();
+            return stream_get_contents($this->stream);
+        } catch (\Throwable) {
+            return '';
+        }
+    }
+
+    /**
+     * Close the underlying stream and detach.
+     *
+     * @return void
+     */
+    public function close(): void
+    {
+        if ($this->stream) {
+            if (is_resource($this->stream)) {
+                fclose($this->stream);
+            }
+            $this->detach();
+        }
+    }
+
+    /**
+     * Detach the underlying resource from the stream.
+     *
+     * @return resource|null
+     */
+    public function detach()
+    {
+        $resource = $this->stream;
+        $this->stream = null;
+        $this->seekable = false;
+        $this->readable = false;
+        $this->writable = false;
+        $this->size = null;
+        $this->metadata = null;
+        return $resource;
+    }
+
+    /**
+     * Get the stream size in bytes.
+     *
+     * @return int|null
+     */
+    public function getSize(): ?int
+    {
+        if ($this->size !== null) {
+            return $this->size;
+        }
+
+        if (!$this->stream) {
+            return null;
+        }
+
+        $stats = fstat($this->stream);
+        $this->size = $stats['size'] ?? null;
+        return $this->size;
+    }
+
+    /**
+     * Get the current position of the stream pointer.
+     *
+     * @return int
+     *
+     * @throws RuntimeException When the stream is detached or unable to determine position.
+     */
+    public function tell(): int
+    {
+        if (!$this->stream) {
+            throw new RuntimeException('Stream is detached');
+        }
+
+        $pos = ftell($this->stream);
+        if ($pos === false) {
+            throw new RuntimeException('Unable to determine stream position');
+        }
+
+        return $pos;
+    }
+
+    /**
+     * Check if the stream pointer is at the end of the stream.
+     *
+     * @return bool
+     */
+    public function eof(): bool
+    {
+        return !$this->stream || feof($this->stream);
+    }
+
+    /**
+     * Check if the stream is seekable.
+     *
+     * @return bool
+     */
+    public function isSeekable(): bool
+    {
+        return $this->seekable;
+    }
+
+    /**
+     * Seek to a position in the stream.
+     *
+     * @param int $offset Offset value.
+     * @param int $whence Seek mode (SEEK_SET, SEEK_CUR, SEEK_END).
+     *
+     * @return void
+     *
+     * @throws RuntimeException When the stream is detached or not seekable, or seek fails.
+     */
+    public function seek(int $offset, int $whence = SEEK_SET): void
+    {
+        if (!$this->stream) {
+            throw new RuntimeException('Stream is detached');
+        }
+
+        if (!$this->seekable) {
+            throw new RuntimeException('Stream is not seekable');
+        }
+
+        if (fseek($this->stream, $offset, $whence) === -1) {
+            throw new RuntimeException('Unable to seek stream');
+        }
+    }
+
+    /**
+     * Rewind to the beginning of the stream.
+     *
+     * @return void
+     */
+    public function rewind(): void
+    {
+        $this->seek(0);
+    }
+
+    /**
+     * Check if the stream is writable.
+     *
+     * @return bool
+     */
+    public function isWritable(): bool
+    {
+        return $this->writable;
+    }
+
+    /**
+     * Write data to the stream.
+     *
+     * @param string $string The string to write.
+     *
+     * @return int Number of bytes written.
+     *
+     * @throws RuntimeException When the stream is detached or not writable, or write fails.
+     */
+    public function write(string $string): int
+    {
+        if (!$this->stream) {
+            throw new RuntimeException('Stream is detached');
+        }
+
+        if (!$this->writable) {
+            throw new RuntimeException('Stream is not writable');
+        }
+
+        $this->size = null;
+        $written = fwrite($this->stream, $string);
+
+        if ($written === false) {
+            throw new RuntimeException('Unable to write to stream');
+        }
+
+        return $written;
+    }
+
+    /**
+     * Check if the stream is readable.
+     *
+     * @return bool
+     */
+    public function isReadable(): bool
+    {
+        return $this->readable;
+    }
+
+    /**
+     * Read data from the stream.
+     *
+     * @param int $length Number of bytes to read.
+     *
+     * @return string
+     *
+     * @throws RuntimeException When the stream is detached or not readable, or read fails.
+     */
+    public function read(int $length): string
+    {
+        if (!$this->stream) {
+            throw new RuntimeException('Stream is detached');
+        }
+
+        if (!$this->readable) {
+            throw new RuntimeException('Stream is not readable');
+        }
+
+        $data = fread($this->stream, $length);
+
+        if ($data === false) {
+            throw new RuntimeException('Unable to read from stream');
+        }
+
+        return $data;
+    }
+
+    /**
+     * Get the remaining contents of the stream.
+     *
+     * @return string
+     *
+     * @throws RuntimeException When the stream is detached or unable to read contents.
+     */
+    public function getContents(): string
+    {
+        if (!$this->stream) {
+            throw new RuntimeException('Stream is detached');
+        }
+
+        $contents = stream_get_contents($this->stream);
+
+        if ($contents === false) {
+            throw new RuntimeException('Unable to read stream contents');
+        }
+
+        return $contents;
+    }
+
+    /**
+     * Get stream metadata.
+     *
+     * @param string|null $key Optional metadata key.
+     *
+     * @return mixed
+     */
+    public function getMetadata(?string $key = null): mixed
+    {
+        if ($this->metadata === null) {
+            return $key === null ? null : null;
+        }
+
+        return $key === null
+            ? $this->metadata
+            : ($this->metadata[$key] ?? null);
+    }
+
+    /**
+     * Cache stream metadata and derive seekable/readable/writable flags.
+     *
+     * @return void
+     */
+    private function setMetadata(): void
+    {
+        $this->metadata = $this->stream
+            ? stream_get_meta_data($this->stream)
+            : null;
+
+        if ($this->metadata) {
+            $mode = $this->metadata['mode'] ?? '';
+            $this->seekable = $this->metadata['seekable'] ?? false;
+            $this->readable = str_contains($mode, 'r') || str_contains($mode, '+');
+            $this->writable = str_contains($mode, 'w')
+                || str_contains($mode, 'a')
+                || str_contains($mode, 'x')
+                || str_contains($mode, 'c')
+                || str_contains($mode, '+');
+        }
+    }
+}

--- a/sdf/core/Http/UploadedFile.php
+++ b/sdf/core/Http/UploadedFile.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SDF\Http;
+
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UploadedFileInterface;
+use RuntimeException;
+
+/**
+ * smskSoft SDF PSR-7 UploadedFile
+ * Copyright devsimsek
+ * @package     SDF
+ * @subpackage  SDF\Http
+ * @file        UploadedFile.php
+ * @version     v1.0.0
+ * @author      devsimsek
+ * @copyright   Copyright (c) 2025, smskSoft, devsimsek
+ * @license     https://opensource.org/licenses/MIT	MIT License
+ * @url         https://github.com/devsimsek/project-sdf/wiki/libraries/http.md
+ * @since       Version 2.0
+ * @filesource
+ */
+class UploadedFile implements UploadedFileInterface
+{
+    /** @var StreamInterface|null Stream for the uploaded file. */
+    private ?StreamInterface $stream = null;
+
+    /** @var string|null Path to the temporary uploaded file. */
+    private ?string $file = null;
+
+    /** @var int|null File size in bytes. */
+    private ?int $size = null;
+
+    /** @var int Upload error code (UPLOAD_ERR_*). */
+    private int $error;
+
+    /** @var string|null Original client filename. */
+    private ?string $clientFilename = null;
+
+    /** @var string|null Client media type. */
+    private ?string $clientMediaType = null;
+
+    /** @var bool Whether the file has been moved. */
+    private bool $moved = false;
+
+    /**
+     * @param string|StreamInterface $file            Temporary file path or stream.
+     * @param int                    $error           Upload error code (UPLOAD_ERR_*).
+     * @param string|null            $clientFilename  Original client filename.
+     * @param string|null            $clientMediaType Client media type.
+     * @param int|null               $size            File size in bytes.
+     */
+    public function __construct(
+        string|StreamInterface $file,
+        int $error = UPLOAD_ERR_OK,
+        ?string $clientFilename = null,
+        ?string $clientMediaType = null,
+        ?int $size = null,
+    ) {
+        $this->error = $error;
+
+        if ($error !== UPLOAD_ERR_OK) {
+            return;
+        }
+
+        if ($file instanceof StreamInterface) {
+            $this->stream = $file;
+        } else {
+            $this->file = $file;
+        }
+
+        $this->clientFilename = $clientFilename;
+        $this->clientMediaType = $clientMediaType;
+        $this->size = $size;
+    }
+
+    /**
+     * Get a stream representing the uploaded file.
+     *
+     * @return StreamInterface
+     *
+     * @throws RuntimeException When the file has already been moved or is unavailable.
+     */
+    public function getStream(): StreamInterface
+    {
+        if ($this->moved) {
+            throw new RuntimeException('Uploaded file has already been moved');
+        }
+
+        if ($this->stream !== null) {
+            return $this->stream;
+        }
+
+        if ($this->file === null) {
+            throw new RuntimeException('No file or stream available');
+        }
+
+        $resource = fopen($this->file, 'r');
+        if ($resource === false) {
+            throw new RuntimeException("Unable to open uploaded file: {$this->file}");
+        }
+
+        $this->stream = new Stream($resource);
+        return $this->stream;
+    }
+
+    /**
+     * Move the uploaded file to a target location.
+     *
+     * @param string $targetPath Destination path.
+     *
+     * @return void
+     *
+     * @throws RuntimeException When the file has already been moved, no temporary file is available,
+     *                          the target directory does not exist, or the move fails.
+     */
+    public function moveTo(string $targetPath): void
+    {
+        if ($this->moved) {
+            throw new RuntimeException('Uploaded file has already been moved');
+        }
+
+        if ($this->file === null) {
+            throw new RuntimeException('No temporary file path available');
+        }
+
+        $dir = dirname($targetPath);
+        if (!is_dir($dir)) {
+            throw new RuntimeException("Target directory does not exist: $dir");
+        }
+
+        if (rename($this->file, $targetPath) === false) {
+            if (!copy($this->file, $targetPath)) {
+                throw new RuntimeException("Unable to move file to: $targetPath");
+            }
+            unlink($this->file);
+        }
+
+        $this->moved = true;
+    }
+
+    /**
+     * Get the file size.
+     *
+     * @return int|null
+     */
+    public function getSize(): ?int
+    {
+        return $this->size;
+    }
+
+    /**
+     * Get the upload error code.
+     *
+     * @return int
+     */
+    public function getError(): int
+    {
+        return $this->error;
+    }
+
+    /**
+     * Get the original client filename.
+     *
+     * @return string|null
+     */
+    public function getClientFilename(): ?string
+    {
+        return $this->clientFilename;
+    }
+
+    /**
+     * Get the client media type.
+     *
+     * @return string|null
+     */
+    public function getClientMediaType(): ?string
+    {
+        return $this->clientMediaType;
+    }
+}

--- a/sdf/core/Http/UploadedFile.php
+++ b/sdf/core/Http/UploadedFile.php
@@ -131,7 +131,11 @@ class UploadedFile implements UploadedFileInterface
             throw new RuntimeException("Target directory does not exist: $dir");
         }
 
-        if (rename($this->file, $targetPath) === false) {
+        if (is_uploaded_file($this->file)) {
+            if (!move_uploaded_file($this->file, $targetPath)) {
+                throw new RuntimeException("Unable to move uploaded file to: $targetPath");
+            }
+        } elseif (rename($this->file, $targetPath) === false) {
             if (!copy($this->file, $targetPath)) {
                 throw new RuntimeException("Unable to move file to: $targetPath");
             }

--- a/sdf/core/Http/Uri.php
+++ b/sdf/core/Http/Uri.php
@@ -1,0 +1,334 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SDF\Http;
+
+use InvalidArgumentException;
+use Psr\Http\Message\UriInterface;
+
+/**
+ * smskSoft SDF PSR-7 URI
+ * Copyright devsimsek
+ * @package     SDF
+ * @subpackage  SDF\Http
+ * @file        Uri.php
+ * @version     v1.0.0
+ * @author      devsimsek
+ * @copyright   Copyright (c) 2025, smskSoft, devsimsek
+ * @license     https://opensource.org/licenses/MIT	MIT License
+ * @url         https://github.com/devsimsek/project-sdf/wiki/libraries/http.md
+ * @since       Version 2.0
+ * @filesource
+ */
+class Uri implements UriInterface
+{
+    private string $scheme = '';
+    private string $userInfo = '';
+    private string $host = '';
+    private ?int $port = null;
+    private string $path = '';
+    private string $query = '';
+    private string $fragment = '';
+
+    /** @var array<string, int|null> Standard ports per scheme. */
+    private const STANDARD_PORTS = [
+        'http' => 80,
+        'https' => 443,
+    ];
+
+    /**
+     * @param string $uri Absolute URI string to parse.
+     *
+     * @throws InvalidArgumentException When the URI cannot be parsed.
+     */
+    public function __construct(string $uri = '')
+    {
+        if ($uri !== '') {
+            $parts = parse_url($uri);
+            if ($parts === false) {
+                throw new InvalidArgumentException("Unable to parse URI: $uri");
+            }
+
+            $this->scheme = isset($parts['scheme']) ? strtolower($parts['scheme']) : '';
+            $this->host = isset($parts['host']) ? strtolower($parts['host']) : '';
+            $this->port = isset($parts['port']) ? (int) $parts['port'] : null;
+            $this->path = $parts['path'] ?? '';
+            $this->query = $parts['query'] ?? '';
+            $this->fragment = $parts['fragment'] ?? '';
+
+            if (isset($parts['user'])) {
+                $this->userInfo = $parts['user'];
+                if (isset($parts['pass'])) {
+                    $this->userInfo .= ':' . $parts['pass'];
+                }
+            }
+        }
+    }
+
+    /**
+     * Get the URI scheme.
+     *
+     * @return string
+     */
+    public function getScheme(): string
+    {
+        return $this->scheme;
+    }
+
+    /**
+     * Get the URI authority (user@host:port).
+     *
+     * @return string
+     */
+    public function getAuthority(): string
+    {
+        if ($this->host === '') {
+            return '';
+        }
+
+        $authority = $this->host;
+
+        if ($this->userInfo !== '') {
+            $authority = $this->userInfo . '@' . $authority;
+        }
+
+        if ($this->port !== null && $this->isNonStandardPort()) {
+            $authority .= ':' . $this->port;
+        }
+
+        return $authority;
+    }
+
+    /**
+     * Get the URI user info.
+     *
+     * @return string
+     */
+    public function getUserInfo(): string
+    {
+        return $this->userInfo;
+    }
+
+    /**
+     * Get the URI host.
+     *
+     * @return string
+     */
+    public function getHost(): string
+    {
+        return $this->host;
+    }
+
+    /**
+     * Get the URI port (null for standard ports).
+     *
+     * @return int|null
+     */
+    public function getPort(): ?int
+    {
+        return $this->isNonStandardPort() ? $this->port : null;
+    }
+
+    /**
+     * Get the URI path.
+     *
+     * @return string
+     */
+    public function getPath(): string
+    {
+        return $this->path;
+    }
+
+    /**
+     * Get the URI query string.
+     *
+     * @return string
+     */
+    public function getQuery(): string
+    {
+        return $this->query;
+    }
+
+    /**
+     * Get the URI fragment.
+     *
+     * @return string
+     */
+    public function getFragment(): string
+    {
+        return $this->fragment;
+    }
+
+    /**
+     * Return an instance with the specified scheme.
+     *
+     * @param string $scheme
+     *
+     * @return static
+     */
+    public function withScheme(string $scheme): UriInterface
+    {
+        $new = clone $this;
+        $new->scheme = strtolower($scheme);
+        return $new;
+    }
+
+    /**
+     * Return an instance with the specified user info.
+     *
+     * @param string      $user
+     * @param string|null $password
+     *
+     * @return static
+     */
+    public function withUserInfo(string $user, ?string $password = null): UriInterface
+    {
+        $new = clone $this;
+        $new->userInfo = $user;
+        if ($password !== null) {
+            $new->userInfo .= ':' . $password;
+        }
+        return $new;
+    }
+
+    /**
+     * Return an instance with the specified host.
+     *
+     * @param string $host
+     *
+     * @return static
+     */
+    public function withHost(string $host): UriInterface
+    {
+        $new = clone $this;
+        $new->host = strtolower($host);
+        return $new;
+    }
+
+    /**
+     * Return an instance with the specified port.
+     *
+     * @param int|null $port
+     *
+     * @return static
+     *
+     * @throws InvalidArgumentException When port is out of range.
+     */
+    public function withPort(?int $port): UriInterface
+    {
+        if ($port !== null && ($port < 1 || $port > 65535)) {
+            throw new InvalidArgumentException("Invalid port: $port");
+        }
+
+        $new = clone $this;
+        $new->port = $port;
+        return $new;
+    }
+
+    /**
+     * Return an instance with the specified path.
+     *
+     * @param string $path
+     *
+     * @return static
+     *
+     * @throws InvalidArgumentException When path is not absolute or empty.
+     */
+    public function withPath(string $path): UriInterface
+    {
+        if (!str_starts_with($path, '/') && $path !== '') {
+            throw new InvalidArgumentException('Path must be absolute (start with "/") or empty');
+        }
+
+        $new = clone $this;
+        $new->path = $path;
+        return $new;
+    }
+
+    /**
+     * Return an instance with the specified query string.
+     *
+     * @param string $query
+     *
+     * @return static
+     */
+    public function withQuery(string $query): UriInterface
+    {
+        if (str_starts_with($query, '?')) {
+            $query = substr($query, 1);
+        }
+
+        $new = clone $this;
+        $new->query = $query;
+        return $new;
+    }
+
+    /**
+     * Return an instance with the specified fragment.
+     *
+     * @param string $fragment
+     *
+     * @return static
+     */
+    public function withFragment(string $fragment): UriInterface
+    {
+        if (str_starts_with($fragment, '#')) {
+            $fragment = substr($fragment, 1);
+        }
+
+        $new = clone $this;
+        $new->fragment = $fragment;
+        return $new;
+    }
+
+    /**
+     * Return the string representation of the URI.
+     *
+     * @return string
+     */
+    public function __toString(): string
+    {
+        $uri = '';
+
+        if ($this->scheme !== '') {
+            $uri .= $this->scheme . ':';
+        }
+
+        $authority = $this->getAuthority();
+        if ($authority !== '') {
+            $uri .= '//' . $authority;
+        }
+
+        $path = $this->path;
+        if ($authority !== '' && $path !== '' && !str_starts_with($path, '/')) {
+            $path = '/' . $path;
+        }
+        $uri .= $path;
+
+        if ($this->query !== '') {
+            $uri .= '?' . $this->query;
+        }
+
+        if ($this->fragment !== '') {
+            $uri .= '#' . $this->fragment;
+        }
+
+        return $uri;
+    }
+
+    /**
+     * Check if the current port is non-standard for the scheme.
+     *
+     * @return bool
+     */
+    private function isNonStandardPort(): bool
+    {
+        if ($this->port === null) {
+            return false;
+        }
+
+        return !isset(self::STANDARD_PORTS[$this->scheme])
+            || self::STANDARD_PORTS[$this->scheme] !== $this->port;
+    }
+}

--- a/sdf/core/Logger.php
+++ b/sdf/core/Logger.php
@@ -284,7 +284,7 @@ class RotatingFileHandler implements HandlerInterface
                         file_put_contents($first . ".gz", gzencode($data));
                         @unlink($first);
                     } else {
-                        // zlib not available — keep rotated uncompressed
+                        // zlib not available - keep rotated uncompressed
                         // leave $first as-is
                     }
                 }

--- a/sdf/core/Middleware/CorsMiddleware.php
+++ b/sdf/core/Middleware/CorsMiddleware.php
@@ -125,9 +125,12 @@ class CorsMiddleware implements Middleware
 
         if ($allowAll && $allowCredentials) {
             header('Access-Control-Allow-Origin: ' . $origin);
-            header('Vary: Origin');
         } else {
             header('Access-Control-Allow-Origin: ' . ($allowAll ? '*' : $origin));
+        }
+
+        if (!$allowAll || $allowCredentials) {
+            header('Vary: Origin');
         }
 
         if ($allowCredentials) {
@@ -153,9 +156,12 @@ class CorsMiddleware implements Middleware
 
         if ($allowAll && $allowCredentials) {
             header('Access-Control-Allow-Origin: ' . $origin);
-            header('Vary: Origin');
         } else {
             header('Access-Control-Allow-Origin: ' . ($allowAll ? '*' : $origin));
+        }
+
+        if (!$allowAll || $allowCredentials) {
+            header('Vary: Origin');
         }
 
         header('Access-Control-Allow-Methods: ' . implode(', ', $config['allowed_methods'] ?? []));

--- a/sdf/core/Middleware/CorsMiddleware.php
+++ b/sdf/core/Middleware/CorsMiddleware.php
@@ -1,0 +1,153 @@
+<?php
+
+/**
+ * smskSoft SDF CORS Middleware
+ * Copyright devsimsek
+ * @package     SDF
+ * @subpackage  SDF Middleware
+ * @file        CorsMiddleware.php
+ * @version     v1.0.0
+ * @author      devsimsek
+ * @copyright   Copyright (c) 2025, smskSoft, devsimsek
+ * @license     https://opensource.org/licenses/MIT	MIT License
+ * @since       Version 2.2
+ * @filesource
+ */
+
+namespace SDF\Middleware;
+
+use Closure;
+use SDF\Core;
+use SDF\Middleware;
+use SDF\Request;
+
+/**
+ * CORS (Cross-Origin Resource Sharing) middleware.
+ *
+ * Handles preflight OPTIONS requests and sets CORS headers on responses.
+ * Configured via app/config/cors.php.
+ *
+ * Register:
+ *   Router::middleware(\SDF\Middleware\CorsMiddleware::class);
+ */
+class CorsMiddleware implements Middleware
+{
+    private ?array $config = null;
+
+    /**
+     * Load CORS config from app/config/cors.php.
+     *
+     * @return array
+     */
+    protected function getConfig(): array
+    {
+        if ($this->config === null) {
+            $this->config = Core::coreGetConfig('cors') ?: [
+                'allowed_origins' => ['*'],
+                'allowed_origins_patterns' => [],
+                'allowed_methods' => ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+                'allowed_headers' => ['Content-Type', 'Authorization', 'X-Requested-With', 'X-CSRF-TOKEN'],
+                'exposed_headers' => [],
+                'max_age' => 86400,
+                'allow_credentials' => false,
+            ];
+        }
+        return $this->config;
+    }
+
+    /**
+     * Handle the request.
+     *
+     * @param Request $request
+     * @param Closure $next
+     * @return mixed
+     */
+    public function handle(Request $request, Closure $next): mixed
+    {
+        $config = $this->getConfig();
+        $origin = $request->header('Origin') ?? '*';
+
+        if (!$this->isOriginAllowed($origin, $config)) {
+            return $next($request);
+        }
+
+        if ($request->isOptions()) {
+            $this->setPreflightHeaders($origin, $config);
+            return '';
+        }
+
+        $response = $next($request);
+
+        $this->setCorsHeaders($origin, $config);
+
+        return $response;
+    }
+
+    /**
+     * Check whether the given origin is allowed.
+     *
+     * @param string $origin
+     * @param array  $config
+     * @return bool
+     */
+    protected function isOriginAllowed(string $origin, array $config): bool
+    {
+        $allowed = $config['allowed_origins'] ?? [];
+
+        if (in_array('*', $allowed, true)) {
+            return true;
+        }
+
+        if (in_array($origin, $allowed, true)) {
+            return true;
+        }
+
+        foreach ($config['allowed_origins_patterns'] ?? [] as $pattern) {
+            if (preg_match($pattern, $origin)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Set CORS headers on the response.
+     *
+     * @param string $origin
+     * @param array  $config
+     * @return void
+     */
+    protected function setCorsHeaders(string $origin, array $config): void
+    {
+        $allowAll = in_array('*', $config['allowed_origins'] ?? [], true);
+
+        header('Access-Control-Allow-Origin: ' . ($allowAll ? '*' : $origin));
+
+        if (!empty($config['allow_credentials'])) {
+            header('Access-Control-Allow-Credentials: true');
+        }
+
+        if (!empty($config['exposed_headers'])) {
+            header('Access-Control-Expose-Headers: ' . implode(', ', $config['exposed_headers']));
+        }
+    }
+
+    /**
+     * Set preflight OPTIONS response headers.
+     *
+     * @param string $origin
+     * @param array  $config
+     * @return void
+     */
+    protected function setPreflightHeaders(string $origin, array $config): void
+    {
+        $originHeader = in_array('*', $config['allowed_origins'] ?? [], true) ? '*' : $origin;
+
+        header('Access-Control-Allow-Origin: ' . $originHeader);
+        header('Access-Control-Allow-Methods: ' . implode(', ', $config['allowed_methods'] ?? []));
+        header('Access-Control-Allow-Headers: ' . implode(', ', $config['allowed_headers'] ?? []));
+        header('Access-Control-Max-Age: ' . ($config['max_age'] ?? 86400));
+        header('HTTP/1.1 204 No Content');
+    }
+}

--- a/sdf/core/Middleware/CorsMiddleware.php
+++ b/sdf/core/Middleware/CorsMiddleware.php
@@ -121,10 +121,16 @@ class CorsMiddleware implements Middleware
     protected function setCorsHeaders(string $origin, array $config): void
     {
         $allowAll = in_array('*', $config['allowed_origins'] ?? [], true);
+        $allowCredentials = !empty($config['allow_credentials']);
 
-        header('Access-Control-Allow-Origin: ' . ($allowAll ? '*' : $origin));
+        if ($allowAll && $allowCredentials) {
+            header('Access-Control-Allow-Origin: ' . $origin);
+            header('Vary: Origin');
+        } else {
+            header('Access-Control-Allow-Origin: ' . ($allowAll ? '*' : $origin));
+        }
 
-        if (!empty($config['allow_credentials'])) {
+        if ($allowCredentials) {
             header('Access-Control-Allow-Credentials: true');
         }
 
@@ -142,12 +148,24 @@ class CorsMiddleware implements Middleware
      */
     protected function setPreflightHeaders(string $origin, array $config): void
     {
-        $originHeader = in_array('*', $config['allowed_origins'] ?? [], true) ? '*' : $origin;
+        $allowAll = in_array('*', $config['allowed_origins'] ?? [], true);
+        $allowCredentials = !empty($config['allow_credentials']);
 
-        header('Access-Control-Allow-Origin: ' . $originHeader);
+        if ($allowAll && $allowCredentials) {
+            header('Access-Control-Allow-Origin: ' . $origin);
+            header('Vary: Origin');
+        } else {
+            header('Access-Control-Allow-Origin: ' . ($allowAll ? '*' : $origin));
+        }
+
         header('Access-Control-Allow-Methods: ' . implode(', ', $config['allowed_methods'] ?? []));
         header('Access-Control-Allow-Headers: ' . implode(', ', $config['allowed_headers'] ?? []));
         header('Access-Control-Max-Age: ' . ($config['max_age'] ?? 86400));
+
+        if ($allowCredentials) {
+            header('Access-Control-Allow-Credentials: true');
+        }
+
         header('HTTP/1.1 204 No Content');
     }
 }

--- a/sdf/core/Middleware/CsrfMiddleware.php
+++ b/sdf/core/Middleware/CsrfMiddleware.php
@@ -1,0 +1,130 @@
+<?php
+
+/**
+ * smskSoft SDF CSRF Middleware
+ * Copyright devsimsek
+ * @package     SDF
+ * @subpackage  SDF Middleware
+ * @file        CsrfMiddleware.php
+ * @version     v1.0.0
+ * @author      devsimsek
+ * @copyright   Copyright (c) 2025, smskSoft, devsimsek
+ * @license     https://opensource.org/licenses/MIT	MIT License
+ * @since       Version 2.2
+ * @filesource
+ */
+
+namespace SDF\Middleware;
+
+use Closure;
+use SDF\HttpResponseException;
+use SDF\Middleware;
+use SDF\Request;
+use SDF\Session;
+
+/**
+ * CSRF protection middleware.
+ *
+ * Validates a per-session token on state-changing requests (POST, PUT, PATCH, DELETE).
+ * Token is provided via X-CSRF-TOKEN header or _token POST field.
+ *
+ * Register:
+ *   Router::middleware(\SDF\Middleware\CsrfMiddleware::class);
+ *
+ * In views use helper functions:
+ *   <?= csrf_field() ?>
+ *   <meta name="csrf-token" content="<?= csrf_token() ?>">
+ */
+class CsrfMiddleware implements Middleware
+{
+    protected string $sessionKey = '_csrf_token';
+
+    /**
+     * @param string|null $sessionKey Optional custom session key.
+     */
+    public function __construct(?string $sessionKey = null)
+    {
+        if ($sessionKey !== null) {
+            $this->sessionKey = $sessionKey;
+        }
+    }
+
+    /**
+     * Handle the request — validate CSRF token on write methods.
+     *
+     * @param Request $request
+     * @param Closure $next
+     * @return mixed
+     * @throws HttpResponseException
+     */
+    public function handle(Request $request, Closure $next): mixed
+    {
+        if (in_array($request->method(), ['POST', 'PUT', 'PATCH', 'DELETE'], true)) {
+            $token = $request->header('X-CSRF-TOKEN')
+                  ?? $request->post('_token');
+
+            if (!$token || !$this->validateToken($token)) {
+                throw new HttpResponseException('CSRF token mismatch.', 419);
+            }
+        }
+
+        return $next($request);
+    }
+
+    /**
+     * Validate the submitted token against the session.
+     *
+     * @param string $token Submitted token.
+     * @return bool
+     */
+    protected function validateToken(string $token): bool
+    {
+        $session = Session::getInstance();
+        $stored = $session->get($this->sessionKey);
+
+        if ($stored === null) {
+            return false;
+        }
+
+        return hash_equals($stored, $token);
+    }
+
+    /**
+     * Generate a new CSRF token and store it in the session.
+     *
+     * @return string
+     */
+    public static function generateToken(): string
+    {
+        $token = bin2hex(random_bytes(32));
+        Session::getInstance()->set('_csrf_token', $token);
+        return $token;
+    }
+
+    /**
+     * Get the current CSRF token (generates one if missing).
+     *
+     * @return string
+     */
+    public static function token(): string
+    {
+        $session = Session::getInstance();
+        $token = $session->get('_csrf_token');
+
+        if ($token === null) {
+            $token = self::generateToken();
+        }
+
+        return $token;
+    }
+
+    /**
+     * Return an HTML hidden input field with the CSRF token.
+     *
+     * @return string
+     */
+    public static function field(): string
+    {
+        return '<input type="hidden" name="_token" value="' . self::token() . '">';
+    }
+}

--- a/sdf/core/Middleware/CsrfMiddleware.php
+++ b/sdf/core/Middleware/CsrfMiddleware.php
@@ -92,27 +92,29 @@ class CsrfMiddleware implements Middleware
     /**
      * Generate a new CSRF token and store it in the session.
      *
+     * @param string $sessionKey Session key to store under (default: '_csrf_token').
      * @return string
      */
-    public static function generateToken(): string
+    public static function generateToken(string $sessionKey = '_csrf_token'): string
     {
         $token = bin2hex(random_bytes(32));
-        Session::getInstance()->set('_csrf_token', $token);
+        Session::getInstance()->set($sessionKey, $token);
         return $token;
     }
 
     /**
      * Get the current CSRF token (generates one if missing).
      *
+     * @param string $sessionKey Session key to read/store under (default: '_csrf_token').
      * @return string
      */
-    public static function token(): string
+    public static function token(string $sessionKey = '_csrf_token'): string
     {
         $session = Session::getInstance();
-        $token = $session->get('_csrf_token');
+        $token = $session->get($sessionKey);
 
         if ($token === null) {
-            $token = self::generateToken();
+            $token = self::generateToken($sessionKey);
         }
 
         return $token;
@@ -121,10 +123,11 @@ class CsrfMiddleware implements Middleware
     /**
      * Return an HTML hidden input field with the CSRF token.
      *
+     * @param string $sessionKey Session key (default: '_csrf_token').
      * @return string
      */
-    public static function field(): string
+    public static function field(string $sessionKey = '_csrf_token'): string
     {
-        return '<input type="hidden" name="_token" value="' . self::token() . '">';
+        return '<input type="hidden" name="_token" value="' . self::token($sessionKey) . '">';
     }
 }

--- a/sdf/core/Middleware/CsrfMiddleware.php
+++ b/sdf/core/Middleware/CsrfMiddleware.php
@@ -37,7 +37,7 @@ use SDF\Session;
  */
 class CsrfMiddleware implements Middleware
 {
-    protected string $sessionKey = '_csrf_token';
+    protected static string $sessionKey = '_csrf_token';
 
     /**
      * @param string|null $sessionKey Optional custom session key.
@@ -45,7 +45,7 @@ class CsrfMiddleware implements Middleware
     public function __construct(?string $sessionKey = null)
     {
         if ($sessionKey !== null) {
-            $this->sessionKey = $sessionKey;
+            self::$sessionKey = $sessionKey;
         }
     }
 
@@ -80,7 +80,7 @@ class CsrfMiddleware implements Middleware
     protected function validateToken(string $token): bool
     {
         $session = Session::getInstance();
-        $stored = $session->get($this->sessionKey);
+        $stored = $session->get(self::$sessionKey);
 
         if ($stored === null) {
             return false;
@@ -95,8 +95,9 @@ class CsrfMiddleware implements Middleware
      * @param string $sessionKey Session key to store under (default: '_csrf_token').
      * @return string
      */
-    public static function generateToken(string $sessionKey = '_csrf_token'): string
+    public static function generateToken(?string $sessionKey = null): string
     {
+        $sessionKey ??= self::$sessionKey;
         $token = bin2hex(random_bytes(32));
         Session::getInstance()->set($sessionKey, $token);
         return $token;
@@ -105,11 +106,12 @@ class CsrfMiddleware implements Middleware
     /**
      * Get the current CSRF token (generates one if missing).
      *
-     * @param string $sessionKey Session key to read/store under (default: '_csrf_token').
+     * @param string|null $sessionKey Session key to read/store under (default: static::$sessionKey).
      * @return string
      */
-    public static function token(string $sessionKey = '_csrf_token'): string
+    public static function token(?string $sessionKey = null): string
     {
+        $sessionKey ??= self::$sessionKey;
         $session = Session::getInstance();
         $token = $session->get($sessionKey);
 
@@ -123,11 +125,13 @@ class CsrfMiddleware implements Middleware
     /**
      * Return an HTML hidden input field with the CSRF token.
      *
-     * @param string $sessionKey Session key (default: '_csrf_token').
+     * @param string|null $sessionKey Session key (default: static::$sessionKey).
      * @return string
      */
-    public static function field(string $sessionKey = '_csrf_token'): string
+    public static function field(?string $sessionKey = null): string
     {
-        return '<input type="hidden" name="_token" value="' . self::token($sessionKey) . '">';
+        $sessionKey ??= self::$sessionKey;
+        $token = self::token($sessionKey);
+        return '<input type="hidden" name="_token" value="' . htmlspecialchars($token, ENT_QUOTES, 'UTF-8') . '">';
     }
 }

--- a/sdf/core/Middleware/RateLimitMiddleware.php
+++ b/sdf/core/Middleware/RateLimitMiddleware.php
@@ -110,22 +110,21 @@ class RateLimitMiddleware implements Middleware
     protected function getAttempts(string $key): int
     {
         $data = Cache::get($key);
-        if ($data === null) {
+        if (!is_array($data)) {
             return 0;
         }
 
-        $decoded = json_decode($data, true);
-        if (!is_array($decoded) || !isset($decoded['attempts'], $decoded['expires_at'])) {
+        if (!isset($data['attempts'], $data['expires_at'])) {
             Cache::delete($key);
             return 0;
         }
 
-        if (time() > $decoded['expires_at']) {
+        if (time() > $data['expires_at']) {
             Cache::delete($key);
             return 0;
         }
 
-        return (int) $decoded['attempts'];
+        return (int) $data['attempts'];
     }
 
     /**
@@ -139,32 +138,22 @@ class RateLimitMiddleware implements Middleware
         $data = Cache::get($key);
         $now = time();
 
-        if ($data === null) {
-            $payload = json_encode([
+        if (!is_array($data) || !isset($data['attempts'])) {
+            $data = [
                 'attempts' => 1,
                 'expires_at' => $now + $this->decaySeconds,
-            ]);
-            Cache::set($key, $payload, $this->decaySeconds);
+            ];
+            Cache::set($key, $data, $this->decaySeconds);
             return;
         }
 
-        $decoded = json_decode($data, true);
-        if (!is_array($decoded) || !isset($decoded['attempts'])) {
-            $payload = json_encode([
-                'attempts' => 1,
-                'expires_at' => $now + $this->decaySeconds,
-            ]);
-            Cache::set($key, $payload, $this->decaySeconds);
-            return;
+        if (time() > ($data['expires_at'] ?? 0)) {
+            $data['attempts'] = 0;
+            $data['expires_at'] = $now + $this->decaySeconds;
         }
 
-        if (time() > ($decoded['expires_at'] ?? 0)) {
-            $decoded['attempts'] = 0;
-            $decoded['expires_at'] = $now + $this->decaySeconds;
-        }
-
-        $decoded['attempts']++;
-        Cache::set($key, json_encode($decoded), $this->decaySeconds);
+        $data['attempts']++;
+        Cache::set($key, $data, $this->decaySeconds);
     }
 
     /**
@@ -176,15 +165,10 @@ class RateLimitMiddleware implements Middleware
     protected function retryAfter(string $key): int
     {
         $data = Cache::get($key);
-        if ($data === null) {
+        if (!is_array($data) || !isset($data['expires_at'])) {
             return $this->decaySeconds;
         }
 
-        $decoded = json_decode($data, true);
-        if (!is_array($decoded) || !isset($decoded['expires_at'])) {
-            return $this->decaySeconds;
-        }
-
-        return max(0, $decoded['expires_at'] - time());
+        return max(0, $data['expires_at'] - time());
     }
 }

--- a/sdf/core/Middleware/RateLimitMiddleware.php
+++ b/sdf/core/Middleware/RateLimitMiddleware.php
@@ -116,6 +116,7 @@ class RateLimitMiddleware implements Middleware
 
         $decoded = json_decode($data, true);
         if (!is_array($decoded) || !isset($decoded['attempts'], $decoded['expires_at'])) {
+            Cache::delete($key);
             return 0;
         }
 
@@ -148,7 +149,12 @@ class RateLimitMiddleware implements Middleware
         }
 
         $decoded = json_decode($data, true);
-        if (!is_array($decoded)) {
+        if (!is_array($decoded) || !isset($decoded['attempts'])) {
+            $payload = json_encode([
+                'attempts' => 1,
+                'expires_at' => $now + $this->decaySeconds,
+            ]);
+            Cache::set($key, $payload, $this->decaySeconds);
             return;
         }
 

--- a/sdf/core/Middleware/RateLimitMiddleware.php
+++ b/sdf/core/Middleware/RateLimitMiddleware.php
@@ -1,0 +1,184 @@
+<?php
+
+/**
+ * smskSoft SDF Rate-Limit Middleware
+ * Copyright devsimsek
+ * @package     SDF
+ * @subpackage  SDF Middleware
+ * @file        RateLimitMiddleware.php
+ * @version     v1.0.0
+ * @author      devsimsek
+ * @copyright   Copyright (c) 2025, smskSoft, devsimsek
+ * @license     https://opensource.org/licenses/MIT	MIT License
+ * @since       Version 2.2
+ * @filesource
+ */
+
+namespace SDF\Middleware;
+
+use Closure;
+use SDF\Cache\Cache;
+use SDF\HttpResponseException;
+use SDF\Middleware;
+use SDF\Request;
+
+/**
+ * Per-IP / per-route rate-limiting middleware.
+ *
+ * Uses the Cache facade for storage.
+ *
+ * Register:
+ *   Router::middleware(\SDF\Middleware\RateLimitMiddleware::class);
+ *
+ * Custom limits per route:
+ *   Router::middleware(new \SDF\Middleware\RateLimitMiddleware(
+ *       maxAttempts: 30, decaySeconds: 60
+ *   ));
+ */
+class RateLimitMiddleware implements Middleware
+{
+    protected int $maxAttempts;
+    protected int $decaySeconds;
+    protected string $prefix = 'ratelimit:';
+
+    /**
+     * @param int    $maxAttempts  Max hits per window (default: 60).
+     * @param int    $decaySeconds Window length in seconds (default: 60).
+     * @param string $prefix       Cache key prefix.
+     */
+    public function __construct(
+        int $maxAttempts = 60,
+        int $decaySeconds = 60,
+        string $prefix = 'ratelimit:',
+    ) {
+        $this->maxAttempts = $maxAttempts;
+        $this->decaySeconds = $decaySeconds;
+        $this->prefix = $prefix;
+    }
+
+    /**
+     * Handle the request — enforce rate limit.
+     *
+     * @param Request $request
+     * @param Closure $next
+     * @return mixed
+     * @throws HttpResponseException
+     */
+    public function handle(Request $request, Closure $next): mixed
+    {
+        $key = $this->resolveKey($request);
+        $attempts = $this->getAttempts($key);
+
+        if ($attempts >= $this->maxAttempts) {
+            $retryAfter = $this->retryAfter($key);
+            header('Retry-After: ' . $retryAfter);
+            header('X-RateLimit-Limit: ' . $this->maxAttempts);
+            header('X-RateLimit-Remaining: 0');
+            header('X-RateLimit-Reset: ' . (time() + $retryAfter));
+            throw new HttpResponseException('Too Many Requests.', 429);
+        }
+
+        $this->hit($key);
+
+        $remaining = max(0, $this->maxAttempts - ($attempts + 1));
+        header('X-RateLimit-Limit: ' . $this->maxAttempts);
+        header('X-RateLimit-Remaining: ' . $remaining);
+        header('X-RateLimit-Reset: ' . (time() + $this->decaySeconds));
+
+        return $next($request);
+    }
+
+    /**
+     * Build the cache key (per-IP + per-route).
+     *
+     * @param Request $request
+     * @return string
+     */
+    protected function resolveKey(Request $request): string
+    {
+        $ip = $request->ip() ?? '127.0.0.1';
+        $path = parse_url($_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH);
+        return $this->prefix . sha1("{$ip}|{$path}");
+    }
+
+    /**
+     * Get current attempt count for the key.
+     *
+     * @param string $key
+     * @return int
+     */
+    protected function getAttempts(string $key): int
+    {
+        $data = Cache::get($key);
+        if ($data === null) {
+            return 0;
+        }
+
+        $decoded = json_decode($data, true);
+        if (!is_array($decoded) || !isset($decoded['attempts'], $decoded['expires_at'])) {
+            return 0;
+        }
+
+        if (time() > $decoded['expires_at']) {
+            Cache::delete($key);
+            return 0;
+        }
+
+        return (int) $decoded['attempts'];
+    }
+
+    /**
+     * Record a hit for the key.
+     *
+     * @param string $key
+     * @return void
+     */
+    protected function hit(string $key): void
+    {
+        $data = Cache::get($key);
+        $now = time();
+
+        if ($data === null) {
+            $payload = json_encode([
+                'attempts' => 1,
+                'expires_at' => $now + $this->decaySeconds,
+            ]);
+            Cache::set($key, $payload, $this->decaySeconds);
+            return;
+        }
+
+        $decoded = json_decode($data, true);
+        if (!is_array($decoded)) {
+            return;
+        }
+
+        if (time() > ($decoded['expires_at'] ?? 0)) {
+            $decoded['attempts'] = 0;
+            $decoded['expires_at'] = $now + $this->decaySeconds;
+        }
+
+        $decoded['attempts']++;
+        Cache::set($key, json_encode($decoded), $this->decaySeconds);
+    }
+
+    /**
+     * Seconds until the client can retry.
+     *
+     * @param string $key
+     * @return int
+     */
+    protected function retryAfter(string $key): int
+    {
+        $data = Cache::get($key);
+        if ($data === null) {
+            return $this->decaySeconds;
+        }
+
+        $decoded = json_decode($data, true);
+        if (!is_array($decoded) || !isset($decoded['expires_at'])) {
+            return $this->decaySeconds;
+        }
+
+        return max(0, $decoded['expires_at'] - time());
+    }
+}

--- a/sdf/core/Request.php
+++ b/sdf/core/Request.php
@@ -647,7 +647,10 @@ class Request
         $_POST = (array) $psr->getParsedBody();
         $_COOKIE = $psr->getCookieParams();
         $_SERVER['REQUEST_METHOD'] = $psr->getMethod();
-        $_SERVER['REQUEST_URI'] = (string) $psr->getUri();
+        $uri = $psr->getUri();
+        $path = $uri->getPath() ?: '/';
+        $query = $uri->getQuery();
+        $_SERVER['REQUEST_URI'] = $query ? $path . '?' . $query : $path;
 
         return $req;
     }

--- a/sdf/core/Request.php
+++ b/sdf/core/Request.php
@@ -591,4 +591,78 @@ class Request
     {
         return $this->scheme() . "://" . $this->host();
     }
+
+    /**
+     * Create a PSR-7 ServerRequest from this legacy request.
+     *
+     * @return \Psr\Http\Message\ServerRequestInterface
+     */
+    public function toPsr(): \Psr\Http\Message\ServerRequestInterface
+    {
+        $uri = new \SDF\Http\Uri($this->origin() . $this->uri());
+
+        $headers = $this->headers();
+        $bodyStr = file_get_contents('php://input') ?: '';
+
+        $psrRequest = new \SDF\Http\ServerRequest(
+            $this->method(),
+            $uri,
+            $headers,
+            new \SDF\Http\Stream($bodyStr),
+            $_SERVER['SERVER_PROTOCOL'] ?? 'HTTP/1.1',
+            $_SERVER,
+        );
+
+        $psrRequest = $psrRequest
+            ->withQueryParams($_GET)
+            ->withCookieParams($_COOKIE)
+            ->withParsedBody($_POST ?: null)
+            ->withUploadedFiles($this->parseFilesToPsr());
+
+        return $psrRequest;
+    }
+
+    /**
+     * Build a legacy Request from a PSR-7 ServerRequest.
+     *
+     * @param \Psr\Http\Message\ServerRequestInterface $psr
+     * @return self
+     */
+    public static function fromPsr(\Psr\Http\Message\ServerRequestInterface $psr): self
+    {
+        $req = new self();
+
+        // Override superglobals to match PSR-7 input
+        $_GET = $psr->getQueryParams();
+        $_POST = (array) $psr->getParsedBody();
+        $_COOKIE = $psr->getCookieParams();
+        $_SERVER['REQUEST_METHOD'] = $psr->getMethod();
+        $_SERVER['REQUEST_URI'] = (string) $psr->getUri();
+
+        return $req;
+    }
+
+    /**
+     * Parse $_FILES into PSR-7 UploadedFile array.
+     *
+     * @return array<string, \Psr\Http\Message\UploadedFileInterface>
+     */
+    private function parseFilesToPsr(): array
+    {
+        $result = [];
+
+        foreach ($_FILES as $key => $spec) {
+            if (isset($spec['tmp_name'])) {
+                $result[$key] = new \SDF\Http\UploadedFile(
+                    $spec['tmp_name'],
+                    $spec['error'] ?? \UPLOAD_ERR_NO_FILE,
+                    $spec['name'] ?? null,
+                    $spec['type'] ?? null,
+                    $spec['size'] ?? null,
+                );
+            }
+        }
+
+        return $result;
+    }
 }

--- a/sdf/core/Request.php
+++ b/sdf/core/Request.php
@@ -253,6 +253,16 @@ class Request
     }
 
     /**
+     * Check if the current request is an OPTIONS request
+     *
+     * @return bool
+     */
+    public function isOptions(): bool
+    {
+        return ($_SERVER["REQUEST_METHOD"] ?? "") === "OPTIONS";
+    }
+
+    /**
      * Check if the current request is an AJAX request
      *
      * @return bool

--- a/sdf/core/Request.php
+++ b/sdf/core/Request.php
@@ -22,6 +22,9 @@ class Request
 {
     use CoreUtilities;
 
+    /** @var array|null Cached parsed JSON body */
+    private ?array $jsonCache = null;
+
     /**
      * Get a value from the $_GET superglobal array
      *
@@ -435,10 +438,15 @@ class Request
      */
     public function ip(): ?string
     {
-        $proxies = $_SERVER["HTTP_X_FORWARDED_FOR"] ?? null;
-        if ($proxies) {
-            $ips = explode(",", $proxies);
-            return trim($ips[0]);
+        $forwarded = $_SERVER["HTTP_X_FORWARDED_FOR"] ?? "";
+        if ($forwarded !== "") {
+            $ips = explode(",", $forwarded);
+            foreach ($ips as $ip) {
+                $ip = trim($ip);
+                if (filter_var($ip, FILTER_VALIDATE_IP)) {
+                    return $ip;
+                }
+            }
         }
         return $_SERVER["HTTP_CLIENT_IP"] ?? ($_SERVER["REMOTE_ADDR"] ?? null);
     }
@@ -564,18 +572,21 @@ class Request
      */
     public function json(): mixed
     {
+        if ($this->jsonCache !== null) {
+            return $this->jsonCache;
+        }
         $contentType = $this->header("Content-Type") ?? "";
         if (
             !str_contains($contentType, "/json") &&
             !str_contains($contentType, "+json")
         ) {
-            return null;
+            return $this->jsonCache = null;
         }
         $body = file_get_contents("php://input");
         if (empty($body)) {
-            return null;
+            return $this->jsonCache = null;
         }
-        return json_decode($body, true);
+        return $this->jsonCache = json_decode($body, true);
     }
 
     /**

--- a/sdf/core/Response.php
+++ b/sdf/core/Response.php
@@ -379,4 +379,40 @@ class Response
         $this->sendHeaders();
         echo $this->content;
     }
+
+    /**
+     * Create a PSR-7 Response from this legacy response.
+     *
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    public function toPsr(): \Psr\Http\Message\ResponseInterface
+    {
+        $headers = $this->namedHeaders;
+
+        return new \SDF\Http\Response(
+            $this->httpCode ?? 200,
+            $headers,
+            new \SDF\Http\Stream($this->content),
+            '1.1',
+        );
+    }
+
+    /**
+     * Build a legacy Response from a PSR-7 ResponseInterface.
+     *
+     * @param \Psr\Http\Message\ResponseInterface $psr
+     * @return self
+     */
+    public static function fromPsr(\Psr\Http\Message\ResponseInterface $psr): self
+    {
+        $res = new self();
+        $res->setHttpCode($psr->getStatusCode());
+        $res->content = (string) $psr->getBody();
+
+        foreach ($psr->getHeaders() as $name => $values) {
+            $res->setHeader($name, implode(', ', $values));
+        }
+
+        return $res;
+    }
 }

--- a/sdf/core/Router.php
+++ b/sdf/core/Router.php
@@ -89,7 +89,7 @@ class Router
         );
 
         if (!$hasTokens) {
-            self::$staticRoutes[$expression][$method] = $controller;
+            self::$staticRoutes[$expression][strtolower($method)] = $controller;
         }
 
         self::$routes[] = [
@@ -201,10 +201,11 @@ class Router
 
         if (!self::$booted) {
             if (file_exists($cacheFile) && !self::$config["debug"]) {
-                $cached = unserialize(file_get_contents($cacheFile));
+                $cached = unserialize(file_get_contents($cacheFile), ['allowed_classes' => false]);
                 self::$routes = $cached["routes"] ?? $cached;
                 self::$staticRoutes = $cached["static"] ?? self::$staticRoutes;
             } else {
+                $prefixedStatic = [];
                 foreach (self::$routes as &$route) {
                     if ($basepath != "" && $basepath != "/") {
                         $route["expression"] = "(" . $basepath . ")" . $route["expression"];
@@ -212,6 +213,12 @@ class Router
                     $route['expression'] = '^' . $route['expression'] . '$';
                 }
                 unset($route);
+                if ($basepath != "" && $basepath != "/") {
+                    foreach (self::$staticRoutes as $path => $methods) {
+                        $prefixedStatic[$basepath . $path] = $methods;
+                    }
+                    self::$staticRoutes = $prefixedStatic;
+                }
                 if (!self::$config["debug"]) {
                     file_put_contents($cacheFile, serialize([
                         "routes" => self::$routes,

--- a/sdf/core/Router.php
+++ b/sdf/core/Router.php
@@ -73,7 +73,7 @@ class Router
      * @param string $method
      * @return void
      */
-    public static function add(string $expression, string $controller, string $method = "any"): void
+    public static function add(string $expression, string|callable $controller, string $method = "any"): void
     {
         $patterns = [
           "{url}" => "([0-9a-zA-Z]+)",
@@ -290,6 +290,15 @@ class Router
      */
     private static function handleController($controller, $controllerDir, $routeMatches): bool
     {
+        if (str_contains($controller, '@')) {
+            $parts = explode('@', $controller);
+            $class = $parts[0];
+            $method = $parts[1] ?? 'index';
+            if (class_exists($class) && method_exists($class, $method)) {
+                return self::callControllerMethod($class, $method, $routeMatches);
+            }
+            return false;
+        }
         $request = explode("/", $controller);
         return self::internalInvoker($request, $controllerDir, $routeMatches);
     }

--- a/sdf/core/Router.php
+++ b/sdf/core/Router.php
@@ -32,6 +32,12 @@ class Router
     protected static array $routes = [];
 
     /**
+     * Static route map for O(1) exact path matching.
+     * @var array<string, array{controller: string, method: string}>
+     */
+    protected static array $staticRoutes = [];
+
+    /**
      * @var array
      */
     protected static array $config = [
@@ -75,11 +81,16 @@ class Router
           "{num}" => "([0-9]+)",
           "{all}" => "(.*)",
         ];
+        $hasTokens = str_contains($expression, "{");
         $expression = str_replace(
             array_keys($patterns),
             array_values($patterns),
             $expression
         );
+
+        if (!$hasTokens) {
+            self::$staticRoutes[$expression][$method] = $controller;
+        }
 
         self::$routes[] = [
           "expression" => $expression,
@@ -190,7 +201,9 @@ class Router
 
         if (!self::$booted) {
             if (file_exists($cacheFile) && !self::$config["debug"]) {
-                self::$routes = unserialize(file_get_contents($cacheFile));
+                $cached = unserialize(file_get_contents($cacheFile));
+                self::$routes = $cached["routes"] ?? $cached;
+                self::$staticRoutes = $cached["static"] ?? self::$staticRoutes;
             } else {
                 foreach (self::$routes as &$route) {
                     if ($basepath != "" && $basepath != "/") {
@@ -198,12 +211,38 @@ class Router
                     }
                     $route['expression'] = '^' . $route['expression'] . '$';
                 }
-                if (!self::$config["debug"]) {
-                    file_put_contents($cacheFile, serialize(self::$routes));
-                }
                 unset($route);
+                if (!self::$config["debug"]) {
+                    file_put_contents($cacheFile, serialize([
+                        "routes" => self::$routes,
+                        "static" => self::$staticRoutes,
+                    ]));
+                }
             }
             self::$booted = true;
+        }
+
+        // Static route fast-path - O(1) hash lookup, avoids preg_match
+        $request_method_lower = strtolower($request_method);
+        $staticMatch = null;
+        if (isset(self::$staticRoutes[$request_path])) {
+            $staticCandidates = self::$staticRoutes[$request_path];
+            if (isset($staticCandidates[$request_method_lower])) {
+                $staticMatch = $staticCandidates[$request_method_lower];
+            } elseif (isset($staticCandidates["any"])) {
+                $staticMatch = $staticCandidates["any"];
+            }
+        }
+        if ($staticMatch !== null) {
+            $path_match_found = true;
+            $route_match_found = true;
+            if (is_callable($staticMatch)) {
+                call_user_func($staticMatch);
+                return;
+            }
+            if (self::handleController($staticMatch, $controllerDir, [])) {
+                return;
+            }
         }
 
         foreach (self::$routes as $route) {
@@ -268,26 +307,28 @@ class Router
      */
     private static function adjustSearchPath($search_path, $request): mixed
     {
-        if (!file_exists($search_path)) {
+        if (!is_dir($search_path)) {
             $search_path = self::$config["controllersDir"] . join("/", array_slice(array_map("ucfirst", $request), 0, -2));
         }
         return $search_path;
     }
 
     /**
-     * Require a controller file.
+     * Require a controller file (suppresses E_WARNING for missing files).
      * @param $search_path
      * @param $controller
      * @return bool
      */
     private static function requireControllerFile($search_path, $controller): bool
     {
-        if (file_exists($search_path . "/" . $controller . ".php")) {
-            require $search_path . "/" . $controller . ".php";
+        $path = $search_path . "/" . $controller . ".php";
+        if (is_file($path)) {
+            require $path;
             return true;
         }
-        if (file_exists($search_path . "/" . ucfirst($controller) . ".php")) {
-            require $search_path . "/" . ucfirst($controller) . ".php";
+        $path = $search_path . "/" . ucfirst($controller) . ".php";
+        if (is_file($path)) {
+            require $path;
             return true;
         }
         return false;

--- a/sdf/core/Router.php
+++ b/sdf/core/Router.php
@@ -188,8 +188,7 @@ class Router
     {
         $routeMatches = [];
 
-        if (self::$booted) {
-            // SDF-2: Load cached routes if exist
+        if (!self::$booted) {
             if (file_exists($cacheFile) && !self::$config["debug"]) {
                 self::$routes = unserialize(file_get_contents($cacheFile));
             } else {

--- a/sdf/core/Session.php
+++ b/sdf/core/Session.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace SDF;
+
+/**
+ * Project SDF Session
+ * Copyright devsimsek
+ * @package     SDF
+ * @subpackage  SDF Core
+ * @file        Session.php
+ * @version     v2.0.0
+ * @author      devsimsek
+ * @copyright   Copyright (c) 2025, smskSoft, devsimsek
+ * @license     https://opensource.org/licenses/MIT	MIT License
+ * @link        https://github.com/devsimsek/project-sdf/wiki/libraries/session
+ * @since       Version 1.0
+ * @filesource
+ */
+class Session
+{
+    /** @var self|null Singleton instance */
+    private static ?Session $instance = null;
+
+    /**
+     * Start or resume a session.
+     *
+     * @param string|null $cacheExpire  Session cache expiration (minutes).
+     * @param string|null $cacheLimiter Session cache limiter header.
+     */
+    public function __construct(
+        ?string $cacheExpire = null,
+        ?string $cacheLimiter = null,
+    ) {
+        if (session_status() === PHP_SESSION_NONE) {
+            if ($cacheLimiter !== null) {
+                session_cache_limiter($cacheLimiter);
+            }
+
+            if ($cacheExpire !== null) {
+                session_cache_expire((int) $cacheExpire);
+            }
+
+            session_start();
+        }
+    }
+
+    /**
+     * Retrieve the singleton instance.
+     *
+     * @param string|null $cacheExpire  Session cache expiration (minutes).
+     * @param string|null $cacheLimiter Session cache limiter header.
+     * @return self
+     */
+    public static function getInstance(
+        ?string $cacheExpire = null,
+        ?string $cacheLimiter = null,
+    ): self {
+        if (self::$instance === null) {
+            self::$instance = new self($cacheExpire, $cacheLimiter);
+        }
+
+        return self::$instance;
+    }
+
+    /**
+     * Retrieve a value from the session.
+     *
+     * @param string $key     Session key.
+     * @param mixed  $default Default value if key does not exist.
+     * @return mixed
+     */
+    public function get(string $key, mixed $default = null): mixed
+    {
+        return array_key_exists($key, $_SESSION) ? $_SESSION[$key] : $default;
+    }
+
+    /**
+     * Store a value in the session.
+     *
+     * @param string $key   Session key.
+     * @param mixed  $value Value to store.
+     * @return $this
+     */
+    public function set(string $key, mixed $value): self
+    {
+        $_SESSION[$key] = $value;
+        return $this;
+    }
+
+    /**
+     * Check if a session key exists.
+     *
+     * @param string $key Session key.
+     * @return bool
+     */
+    public function has(string $key): bool
+    {
+        return array_key_exists($key, $_SESSION);
+    }
+
+    /**
+     * Remove a value from the session.
+     *
+     * @param string $key Session key.
+     * @return void
+     */
+    public function remove(string $key): void
+    {
+        unset($_SESSION[$key]);
+    }
+
+    /**
+     * Clear all session data.
+     *
+     * @return void
+     */
+    public function clear(): void
+    {
+        session_unset();
+    }
+
+    /**
+     * Get the current session ID.
+     *
+     * @return string|false
+     */
+    public function id(): string|false
+    {
+        return session_id();
+    }
+
+    /**
+     * Regenerate the session ID.
+     *
+     * @param bool $deleteOld Whether to delete the old session data.
+     * @return $this
+     */
+    public function regenerate(bool $deleteOld = false): self
+    {
+        session_regenerate_id($deleteOld);
+        return $this;
+    }
+
+    /**
+     * Destroy the session and its data.
+     *
+     * @return void
+     */
+    public function destroy(): void
+    {
+        $_SESSION = [];
+        session_destroy();
+    }
+}

--- a/sdf/core/Session.php
+++ b/sdf/core/Session.php
@@ -1,14 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace SDF;
 
 /**
- * Project SDF Session
+ * smskSoft SDF Session
  * Copyright devsimsek
  * @package     SDF
  * @subpackage  SDF Core
  * @file        Session.php
- * @version     v2.0.0
+ * @version     v2.1.0
  * @author      devsimsek
  * @copyright   Copyright (c) 2025, smskSoft, devsimsek
  * @license     https://opensource.org/licenses/MIT	MIT License
@@ -21,31 +23,29 @@ class Session
     /** @var self|null Singleton instance */
     private static ?Session $instance = null;
 
+    /** @var bool Whether session_start() has been called */
+    private bool $started = false;
+
+    /** @var string|null Cache expiration override */
+    private ?string $cacheExpire = null;
+
+    /** @var string|null Cache limiter override */
+    private ?string $cacheLimiter = null;
+
     /**
-     * Start or resume a session.
-     *
      * @param string|null $cacheExpire  Session cache expiration (minutes).
      * @param string|null $cacheLimiter Session cache limiter header.
      */
-    public function __construct(
+    final public function __construct(
         ?string $cacheExpire = null,
         ?string $cacheLimiter = null,
     ) {
-        if (session_status() === PHP_SESSION_NONE) {
-            if ($cacheLimiter !== null) {
-                session_cache_limiter($cacheLimiter);
-            }
-
-            if ($cacheExpire !== null) {
-                session_cache_expire((int) $cacheExpire);
-            }
-
-            session_start();
-        }
+        $this->cacheExpire = $cacheExpire;
+        $this->cacheLimiter = $cacheLimiter;
     }
 
     /**
-     * Retrieve the singleton instance.
+     * Retrieve the singleton instance (lazy - session_start on first data access).
      *
      * @param string|null $cacheExpire  Session cache expiration (minutes).
      * @param string|null $cacheLimiter Session cache limiter header.
@@ -63,6 +63,32 @@ class Session
     }
 
     /**
+     * Ensure the session has been started.
+     *
+     * @return void
+     */
+    private function ensureStarted(): void
+    {
+        if ($this->started) {
+            return;
+        }
+
+        if (session_status() === PHP_SESSION_NONE) {
+            if ($this->cacheLimiter !== null) {
+                session_cache_limiter($this->cacheLimiter);
+            }
+
+            if ($this->cacheExpire !== null) {
+                session_cache_expire((int) $this->cacheExpire);
+            }
+
+            session_start();
+        }
+
+        $this->started = true;
+    }
+
+    /**
      * Retrieve a value from the session.
      *
      * @param string $key     Session key.
@@ -71,6 +97,7 @@ class Session
      */
     public function get(string $key, mixed $default = null): mixed
     {
+        $this->ensureStarted();
         return array_key_exists($key, $_SESSION) ? $_SESSION[$key] : $default;
     }
 
@@ -83,6 +110,7 @@ class Session
      */
     public function set(string $key, mixed $value): self
     {
+        $this->ensureStarted();
         $_SESSION[$key] = $value;
         return $this;
     }
@@ -95,6 +123,7 @@ class Session
      */
     public function has(string $key): bool
     {
+        $this->ensureStarted();
         return array_key_exists($key, $_SESSION);
     }
 
@@ -106,6 +135,7 @@ class Session
      */
     public function remove(string $key): void
     {
+        $this->ensureStarted();
         unset($_SESSION[$key]);
     }
 
@@ -116,6 +146,7 @@ class Session
      */
     public function clear(): void
     {
+        $this->ensureStarted();
         session_unset();
     }
 
@@ -126,6 +157,7 @@ class Session
      */
     public function id(): string|false
     {
+        $this->ensureStarted();
         return session_id();
     }
 
@@ -137,6 +169,7 @@ class Session
      */
     public function regenerate(bool $deleteOld = false): self
     {
+        $this->ensureStarted();
         session_regenerate_id($deleteOld);
         return $this;
     }
@@ -148,6 +181,7 @@ class Session
      */
     public function destroy(): void
     {
+        $this->ensureStarted();
         $_SESSION = [];
         session_destroy();
     }

--- a/sdf/core/Spark.php
+++ b/sdf/core/Spark.php
@@ -134,6 +134,15 @@ class Spark
     }
 
     /**
+     * Disconnect and reset the default connection.
+     */
+    public static function disconnect(): void
+    {
+        self::$pdo = null;
+        Pool::remove('default');
+    }
+
+    /**
      * Get the connection pool manager.
      *
      * @return class-string<Pool>
@@ -204,6 +213,12 @@ class QueryBuilder
 
     /** @var string|null $modelClass Optional class name to hydrate results into. */
     protected ?string $modelClass = null;
+
+    /** @var string|null $columns Optional custom SELECT columns. */
+    protected ?string $columns = null;
+
+    /** @var array $joins List of JOIN clauses. */
+    protected array $joins = [];
 
     /**
      * Initialize builder with table.
@@ -285,19 +300,70 @@ class QueryBuilder
     }
 
     /**
+     * Set custom SELECT columns.
+     *
+     * @param string $columns
+     * @return self
+     */
+    public function select(string $columns): self
+    {
+        $this->columns = $columns;
+        return $this;
+    }
+
+    /**
+     * Add a JOIN clause.
+     *
+     * @param string $table    Joined table name.
+     * @param string $first    First column.
+     * @param string $operator Comparison operator.
+     * @param string $second   Second column.
+     * @param string $type     Join type (INNER, LEFT, RIGHT).
+     * @return self
+     */
+    public function join(string $table, string $first, string $operator, string $second, string $type = 'INNER'): self
+    {
+        $type = strtoupper($type);
+        $type = in_array($type, ['INNER', 'LEFT', 'RIGHT', 'FULL'], true) ? $type : 'INNER';
+        $this->joins[] = " $type JOIN " . $this->quoteIdent($table) . " ON " . $this->quoteIdent($first) . " $operator " . $this->quoteIdent($second);
+        return $this;
+    }
+
+    /**
+     * Build the SELECT clause.
+     *
+     * @return string
+     */
+    private function buildSelect(): string
+    {
+        $sql = "SELECT " . ($this->columns ?? "*") . " FROM " . $this->quoteIdent($this->table);
+
+        if (!empty($this->joins)) {
+            $sql .= implode('', $this->joins);
+        }
+
+        if (!empty($this->wheres)) {
+            $sql .= " WHERE " . implode(" AND ", $this->wheres);
+        }
+
+        $sql .= $this->orderBy ?? "";
+        $sql .= $this->limit ?? "";
+
+        return $sql;
+    }
+
+    /**
      * Get the first record matching the query.
      *
      * @return mixed
      */
     public function first(): mixed
     {
-        $sql = "SELECT * FROM " . $this->quoteIdent($this->table);
-        if (!empty($this->wheres)) {
-            $sql .= " WHERE " . implode(" AND ", $this->wheres);
-        }
-
-        $sql .= $this->orderBy ?? "";
-        $sql .= " LIMIT 1";
+        $savedLimit = $this->limit;
+        $savedBindings = $this->bindings;
+        $this->limit = " LIMIT 1";
+        $sql = $this->buildSelect();
+        $this->limit = $savedLimit;
 
         $stmt = Spark::pdo()->prepare($sql);
         $stmt->execute($this->bindings);
@@ -321,13 +387,7 @@ class QueryBuilder
      */
     public function get(): array
     {
-        $sql = "SELECT * FROM " . $this->quoteIdent($this->table);
-        if (!empty($this->wheres)) {
-            $sql .= " WHERE " . implode(" AND ", $this->wheres);
-        }
-
-        $sql .= $this->orderBy ?? "";
-        $sql .= $this->limit ?? "";
+        $sql = $this->buildSelect();
 
         $stmt = Spark::pdo()->prepare($sql);
         $stmt->execute($this->bindings);
@@ -428,5 +488,28 @@ class QueryBuilder
         }
         $stmt = Spark::pdo()->prepare($sql);
         return $stmt->execute($this->bindings);
+    }
+
+    /**
+     * Paginate the query results.
+     *
+     * @param int      $perPage Number of items per page.
+     * @param int|null $page    Current page (defaults to $_GET['page'] ?? 1).
+     * @return \SDF\Spark\Paginator
+     */
+    public function paginate(int $perPage = 15, ?int $page = null): \SDF\Spark\Paginator
+    {
+        $page = $page ?: (int)($_GET['page'] ?? 1);
+        $page = max(1, $page);
+
+        $total = $this->count();
+
+        $offset = ($page - 1) * $perPage;
+        $this->limit = " LIMIT $perPage OFFSET $offset";
+
+        $items = $this->get();
+        $this->limit = null;
+
+        return new \SDF\Spark\Paginator($items, $total, $perPage, $page);
     }
 }

--- a/sdf/core/Spark.php
+++ b/sdf/core/Spark.php
@@ -77,7 +77,7 @@ class Spark
                 if ($path === null) {
                     throw new \Exception('SQLite configuration missing path/dsn');
                 }
-                self::connect(str_contains($path, ':') ? $path : 'sqlite:' . $path);
+                self::connect(str_starts_with($path, 'sqlite:') ? $path : 'sqlite:' . $path);
                 break;
             case 'sqlsrv':
                 $server = $dbConfig['host'] . ',' . ($dbConfig['port'] ?? '1433');

--- a/sdf/core/Spark.php
+++ b/sdf/core/Spark.php
@@ -30,10 +30,7 @@ class Spark
      */
     public static function connect(string $dsn, ?string $username = null, ?string $password = null, array $options = [], bool $persistent = false): void
     {
-        if ($persistent) {
-            $options[PDO::ATTR_PERSISTENT] = true;
-        }
-        Pool::add('default', $dsn, $username, $password, $options);
+        Pool::add('default', $dsn, $username, $password, $options, $persistent);
     }
 
     /**
@@ -89,8 +86,12 @@ class Spark
                 }
                 break;
             case 'manual':
+                $dsn = $dbConfig['dsn'] ?? '';
+                if ($dsn === '') {
+                    throw new \Exception('Spark ORM: manual driver requires a non-empty dsn in config/database.php');
+                }
                 $args = isset($dbConfig['args']) && is_array($dbConfig['args']) ? $dbConfig['args'] : [];
-                self::connect($dbConfig['dsn'] ?? '', ...$args);
+                self::connect($dsn, ...$args);
                 break;
         }
     }
@@ -499,16 +500,20 @@ class QueryBuilder
      */
     public function paginate(int $perPage = 15, ?int $page = null): \SDF\Spark\Paginator
     {
-        $page = $page ?: (int)($_GET['page'] ?? 1);
+        $page = $page ?? (int)($_GET['page'] ?? 1);
         $page = max(1, $page);
+
+        $savedLimit = $this->limit;
+        $savedBindings = $this->bindings;
 
         $total = $this->count();
 
+        $this->bindings = $savedBindings;
         $offset = ($page - 1) * $perPage;
         $this->limit = " LIMIT $perPage OFFSET $offset";
 
         $items = $this->get();
-        $this->limit = null;
+        $this->limit = $savedLimit;
 
         return new \SDF\Spark\Paginator($items, $total, $perPage, $page);
     }

--- a/sdf/core/Spark.php
+++ b/sdf/core/Spark.php
@@ -19,7 +19,7 @@ class Spark
     private static ?PDO $pdo = null;
 
     /**
-     * Establish database connection (lazy — actual connect on first query).
+     * Establish database connection (lazy - actual connect on first query).
      *
      * @param string $dsn      Data Source Name.
      * @param string|null $username Database username.
@@ -37,12 +37,74 @@ class Spark
     }
 
     /**
+     * Auto-initialize from app/config/database.php if no pool config exists.
+     */
+    private static function connectFromConfig(): void
+    {
+        if (Pool::has('default')) {
+            return;
+        }
+        $dbConfig = Core::coreGetConfig('database');
+        if (!$dbConfig || !isset($dbConfig['driver'])) {
+            return;
+        }
+        self::configureFromArray($dbConfig);
+    }
+
+    /**
+     * Parse a config array and call connect() with the right DSN.
+     */
+    private static function configureFromArray(array $dbConfig): void
+    {
+        switch ($dbConfig['driver']) {
+            case 'mysql':
+                $dsn = 'mysql:host=' . ($dbConfig['host'] ?? '127.0.0.1')
+                     . ';dbname=' . ($dbConfig['name'] ?? '')
+                     . ';port=' . ($dbConfig['port'] ?? '3306')
+                     . ';charset=' . ($dbConfig['charset'] ?? 'utf8mb4');
+                self::connect($dsn, $dbConfig['user'] ?? null, $dbConfig['password'] ?? null);
+                break;
+            case 'psql':
+            case 'pgsql':
+            case 'postgres':
+                $dsn = 'pgsql:host=' . ($dbConfig['host'] ?? '127.0.0.1')
+                     . ';dbname=' . ($dbConfig['name'] ?? '')
+                     . ';port=' . ($dbConfig['port'] ?? '5432');
+                self::connect($dsn, $dbConfig['user'] ?? null, $dbConfig['password'] ?? null);
+                break;
+            case 'sqlite':
+                $path = $dbConfig['path'] ?? ($dbConfig['dsn'] ?? null);
+                if ($path === null) {
+                    throw new \Exception('SQLite configuration missing path/dsn');
+                }
+                self::connect(str_contains($path, ':') ? $path : 'sqlite:' . $path);
+                break;
+            case 'sqlsrv':
+                $server = $dbConfig['host'] . ',' . ($dbConfig['port'] ?? '1433');
+                $dsn = 'sqlsrv:Server=' . $server . ';database=' . ($dbConfig['name'] ?? '');
+                if (!empty($dbConfig['auth'])) {
+                    self::connect($dsn);
+                } else {
+                    self::connect($dsn, $dbConfig['user'] ?? null, $dbConfig['password'] ?? null);
+                }
+                break;
+            case 'manual':
+                $args = isset($dbConfig['args']) && is_array($dbConfig['args']) ? $dbConfig['args'] : [];
+                self::connect($dbConfig['dsn'] ?? '', ...$args);
+                break;
+        }
+    }
+
+    /**
      * Ensure the lazy connection is established.
      */
     private static function ensureConnected(): void
     {
         if (self::$pdo !== null) {
             return;
+        }
+        if (!Pool::has('default')) {
+            self::connectFromConfig();
         }
         if (!Pool::has('default')) {
             throw new Exception("Spark ORM: Database not connected.");
@@ -110,8 +172,15 @@ class QueryBuilder
         $parts = explode('.', $identifier);
         $out = [];
         foreach ($parts as $part) {
-            if (!preg_match('/^[A-Za-z0-9_]+$/', $part)) {
+            $len = strlen($part);
+            if ($len === 0) {
                 throw new \InvalidArgumentException('Invalid identifier: ' . $identifier);
+            }
+            for ($i = 0; $i < $len; $i++) {
+                $c = $part[$i];
+                if (!($c >= 'a' && $c <= 'z') && !($c >= 'A' && $c <= 'Z') && !($c >= '0' && $c <= '9') && $c !== '_') {
+                    throw new \InvalidArgumentException('Invalid identifier: ' . $identifier);
+                }
             }
             $out[] = "`" . $part . "`";
         }

--- a/sdf/core/Spark/Model.php
+++ b/sdf/core/Spark/Model.php
@@ -198,17 +198,7 @@ abstract class Model
      */
     public static function find(mixed $id): ?static
     {
-        $data = static::query()->where(static::$primaryKey, $id)->first();
-        if ($data instanceof static) {
-            return $data;
-        }
-
-        if (is_array($data)) {
-            $class = static::class;
-            return new $class($data, true);
-        }
-
-        return null;
+        return static::query()->where(static::$primaryKey, $id)->first();
     }
 
     /**
@@ -414,29 +404,23 @@ abstract class Model
             if (is_string($v)) {
                 $s = trim($v);
 
-                // null-ish
                 if ($s === '') {
                     return $v;
                 }
 
-                // boolean-ish
-                $lower = strtolower($s);
-                if (in_array($lower, ['true','false','1','0','yes','no'], true)) {
-                    return in_array($lower, ['true','1','yes'], true);
-                }
-
-                // integer
                 if (ctype_digit($s) || preg_match('/^[+-]?\d+$/', $s)) {
-                    // protect large ints: intval is fine for typical ranges
-                    return (int)$s;
+                    return (int) $s;
                 }
 
-                // float (decimal or exponent)
-                if (is_numeric($s) && (str_contains($s, '.') || stripos($s, 'e') !== false)) {
-                    return (float)$s;
+                if (is_numeric($s)) {
+                    return (float) $s;
                 }
 
-                // json array/object -> decode
+                $lower = strtolower($s);
+                if (in_array($lower, ['true','false','yes','no'], true)) {
+                    return in_array($lower, ['true','yes'], true);
+                }
+
                 if (($json = json_decode($s, true)) !== null && json_last_error() === JSON_ERROR_NONE) {
                     return $json;
                 }

--- a/sdf/core/Spark/Model.php
+++ b/sdf/core/Spark/Model.php
@@ -221,7 +221,11 @@ abstract class Model
      */
     public static function where(string $column, mixed $operator, mixed $value = null): QueryBuilder
     {
-        return self::query()->where($column, $operator, $value);
+        $qb = static::query();
+        if (func_num_args() === 2) {
+            return $qb->where($column, $operator);
+        }
+        return $qb->where($column, $operator, $value);
     }
 
     /**
@@ -266,7 +270,138 @@ abstract class Model
         return $query->delete();
     }
 
-    // todo: write documentation & tests
+    /**
+     * Define a one-to-one relationship.
+     *
+     * @param string      $related    Related model class name.
+     * @param string|null $foreignKey Foreign key on the related table.
+     * @param string|null $localKey   Local key on this model's table.
+     * @return static|null
+     */
+    public function hasOne(string $related, ?string $foreignKey = null, ?string $localKey = null): ?object
+    {
+        $instance = new $related();
+        $localKey = $localKey ?? static::$primaryKey;
+        $foreignKey = $foreignKey ?? self::classToSnake(static::class) . '_id';
+
+        return $instance::where($foreignKey, $this->attributes[$localKey] ?? null)->first();
+    }
+
+    /**
+     * Define a one-to-many relationship.
+     *
+     * @param string      $related    Related model class name.
+     * @param string|null $foreignKey Foreign key on the related table.
+     * @param string|null $localKey   Local key on this model's table.
+     * @return object[]
+     */
+    public function hasMany(string $related, ?string $foreignKey = null, ?string $localKey = null): array
+    {
+        $instance = new $related();
+        $localKey = $localKey ?? static::$primaryKey;
+        $foreignKey = $foreignKey ?? self::classToSnake(static::class) . '_id';
+
+        return $instance::where($foreignKey, $this->attributes[$localKey] ?? null)->get();
+    }
+
+    /**
+     * Define an inverse one-to-one or many relationship.
+     *
+     * @param string      $related   Parent model class name.
+     * @param string|null $foreignKey Foreign key on this model's table.
+     * @param string|null $ownerKey  Owner key on the parent table.
+     * @return object|null
+     */
+    public function belongsTo(string $related, ?string $foreignKey = null, ?string $ownerKey = null): ?object
+    {
+        $instance = new $related();
+        $ownerKey = $ownerKey ?? $instance->getPrimaryKey();
+        $foreignKey = $foreignKey ?? $this->guessForeignKey($related);
+
+        return $instance::where($ownerKey, $this->attributes[$foreignKey] ?? null)->first();
+    }
+
+    /**
+     * Define a many-to-many relationship.
+     *
+     * @param string      $related         Related model class name.
+     * @param string|null $pivotTable      Pivot table name.
+     * @param string|null $foreignPivotKey Foreign key on the pivot table for this model.
+     * @param string|null $relatedPivotKey Foreign key on the pivot table for the related model.
+     * @return static[]
+     */
+    public function belongsToMany(string $related, ?string $pivotTable = null, ?string $foreignPivotKey = null, ?string $relatedPivotKey = null): array
+    {
+        $instance = new $related();
+        $pivotTable = $pivotTable ?? $this->guessPivotTable(static::class, $related);
+        $foreignPivotKey = $foreignPivotKey ?? $this->guessForeignKey(static::class);
+        $relatedPivotKey = $relatedPivotKey ?? $this->guessForeignKey($related);
+        $localValue = $this->attributes[static::$primaryKey] ?? null;
+
+        if ($localValue === null) {
+            return [];
+        }
+
+        $relatedTable = $instance::getTable();
+        $relatedPk = $instance->getPrimaryKey();
+
+        $query = Spark::table($pivotTable)
+            ->select("{$relatedTable}.*")
+            ->as($related)
+            ->join($relatedTable, "{$relatedTable}.{$relatedPk}", '=', "{$pivotTable}.{$relatedPivotKey}")
+            ->where("{$pivotTable}.{$foreignPivotKey}", $localValue);
+
+        return $query->get();
+    }
+
+    /**
+     * Get the primary key column name.
+     *
+     * @return string
+     */
+    public function getPrimaryKey(): string
+    {
+        return static::$primaryKey;
+    }
+
+    /**
+     * Convert a PascalCase class name to snake_case table name.
+     *
+     * @param string $class
+     * @return string
+     */
+    private static function classToSnake(string $class): string
+    {
+        $parts = explode('\\', $class);
+        $name = end($parts);
+        return strtolower(preg_replace('/(?<!^)[A-Z]/', '_$0', $name));
+    }
+
+    /**
+     * Guess the foreign key column name for a given class.
+     *
+     * @param string $class
+     * @return string
+     */
+    private function guessForeignKey(string $class): string
+    {
+        return self::classToSnake($class) . '_id';
+    }
+
+    /**
+     * Guess the pivot table name from two class names.
+     *
+     * @param string $class1
+     * @param string $class2
+     * @return string
+     */
+    private function guessPivotTable(string $class1, string $class2): string
+    {
+        $tables = [self::classToSnake($class1), self::classToSnake($class2)];
+        sort($tables);
+        return implode('_', $tables);
+    }
+
     public function toArray(): array
     {
         $data = $this->attributes;

--- a/sdf/core/Spark/Paginator.php
+++ b/sdf/core/Spark/Paginator.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * smskSoft SDF Spark Paginator
+ * Copyright devsimsek
+ * @package     SDF
+ * @subpackage  SDF Spark
+ * @file        Paginator.php
+ * @version     v1.0.0
+ * @author      devsimsek
+ * @copyright   Copyright (c) 2024, smskSoft, devsimsek
+ * @license     https://opensource.org/licenses/MIT MIT License
+ * @url         https://github.com/devsimsek/project-sdf/wiki/libraries/spark.md#paginator
+ * @since       Version 2.1
+ * @filesource
+ */
+
+declare(strict_types=1);
+
+namespace SDF\Spark;
+
+class Paginator
+{
+    private array $items;
+    private int $total;
+    private int $perPage;
+    private int $currentPage;
+    private int $lastPage;
+
+    public function __construct(array $items, int $total, int $perPage, int $currentPage)
+    {
+        $this->items = $items;
+        $this->total = $total;
+        $this->perPage = $perPage;
+        $this->currentPage = $currentPage;
+        $this->lastPage = (int)ceil($total / max($perPage, 1));
+    }
+
+    public function items(): array
+    {
+        return $this->items;
+    }
+
+    public function total(): int
+    {
+        return $this->total;
+    }
+
+    public function perPage(): int
+    {
+        return $this->perPage;
+    }
+
+    public function currentPage(): int
+    {
+        return $this->currentPage;
+    }
+
+    public function lastPage(): int
+    {
+        return $this->lastPage;
+    }
+
+    public function hasMore(): bool
+    {
+        return $this->currentPage < $this->lastPage;
+    }
+
+    public function hasPages(): bool
+    {
+        return $this->lastPage > 1;
+    }
+
+    public function onFirstPage(): bool
+    {
+        return $this->currentPage === 1;
+    }
+
+    public function isEmpty(): bool
+    {
+        return empty($this->items);
+    }
+
+    public function isNotEmpty(): bool
+    {
+        return !$this->isEmpty();
+    }
+
+    public function count(): int
+    {
+        return count($this->items);
+    }
+
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->items);
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'items' => array_map(fn ($item) => is_object($item) && method_exists($item, 'toArray') ? $item->toArray() : $item, $this->items),
+            'pagination' => [
+                'total' => $this->total,
+                'per_page' => $this->perPage,
+                'current_page' => $this->currentPage,
+                'last_page' => $this->lastPage,
+                'has_more' => $this->hasMore(),
+            ],
+        ];
+    }
+}

--- a/sdf/core/Swagger/SwaggerController.php
+++ b/sdf/core/Swagger/SwaggerController.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SDF\Swagger;
+
+use SDF\Controller;
+
+/**
+ * smskSoft SDF Swagger Controller
+ * Copyright devsimsek
+ * @package     SDF
+ * @subpackage  SDF\Swagger
+ * @file        SwaggerController.php
+ * @version     v1.0.0
+ * @author      devsimsek
+ * @copyright   Copyright (c) 2025, smskSoft, devsimsek
+ * @license     https://opensource.org/licenses/MIT	MIT License
+ * @url         https://github.com/devsimsek/project-sdf/wiki/libraries/swagger
+ * @since       Version 2.0
+ * @filesource
+ */
+class SwaggerController extends Controller
+{
+    /**
+     * GET /api/openapi.json
+     *
+     * Expose the generated OpenAPI 3.x spec as JSON.
+     *
+     * @return void
+     */
+    public function spec(): void
+    {
+        $generator = new SwaggerGenerator(
+            title: 'SDF API',
+            apiVersion: SDF_VERSION,
+            description: 'SDF Framework API documentation - automatically generated from #[OA\...] attributes.',
+        );
+
+        $this->response
+            ->json(json_decode($generator->generate(), true));
+    }
+
+    /**
+     * GET /api/docs
+     *
+     * Render Swagger UI via CDN.
+     *
+     * @return void
+     */
+    public function docs(): void
+    {
+        $specUrl = '/api/openapi.json';
+
+        $html = <<<HTML
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SDF API Documentation</title>
+    <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css">
+</head>
+<body>
+    <div id="swagger-ui"></div>
+    <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
+    <script>
+        SwaggerUIBundle({
+            url: '{$specUrl}',
+            dom_id: '#swagger-ui',
+            deepLinking: true,
+            presets: [
+                SwaggerUIBundle.presets.apis,
+                SwaggerUIBundle.SwaggerUIStandalonePreset,
+            ],
+            layout: "BaseLayout",
+        });
+    </script>
+</body>
+</html>
+HTML;
+
+        echo $html;
+    }
+}

--- a/sdf/core/Swagger/SwaggerController.php
+++ b/sdf/core/Swagger/SwaggerController.php
@@ -37,8 +37,8 @@ class SwaggerController extends Controller
             description: 'SDF Framework API documentation - automatically generated from #[OA\...] attributes.',
         );
 
-        $this->response
-            ->json(json_decode($generator->generate(), true));
+        header('Content-Type: application/json');
+        echo $generator->generate();
     }
 
     /**

--- a/sdf/core/Swagger/SwaggerGenerator.php
+++ b/sdf/core/Swagger/SwaggerGenerator.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SDF\Swagger;
+
+use OpenApi\Annotations\Info;
+use OpenApi\Annotations\PathItem;
+use OpenApi\Annotations\Server;
+use OpenApi\Generator;
+
+/**
+ * smskSoft SDF Swagger Generator
+ * Copyright devsimsek
+ * @package     SDF
+ * @subpackage  SDF\Swagger
+ * @file        SwaggerGenerator.php
+ * @version     v1.0.0
+ * @author      devsimsek
+ * @copyright   Copyright (c) 2025, smskSoft, devsimsek
+ * @license     https://opensource.org/licenses/MIT	MIT License
+ * @url         https://github.com/devsimsek/project-sdf/wiki/libraries/swagger
+ * @since       Version 2.0
+ * @filesource
+ */
+class SwaggerGenerator
+{
+    /** @var string|null Custom API title. */
+    private ?string $title = null;
+
+    /** @var string|null Custom API version. */
+    private ?string $apiVersion = null;
+
+    /** @var string|null Custom server URL. */
+    private ?string $serverUrl = null;
+
+    /** @var string|null Custom description. */
+    private ?string $description = null;
+
+    /** @var string|null OpenAPI spec version override. */
+    private ?string $specVersion = null;
+
+    /** @var array<int, string> Additional directories to scan. */
+    private array $extraPaths = [];
+
+    /**
+     * @param string|null $title      API title (default: "SDF API").
+     * @param string|null $apiVersion API version (default: "1.0.0").
+     * @param string|null $serverUrl  Server URL (default: inferred from request or "http://localhost").
+     * @param string|null $description API description.
+     */
+    public function __construct(
+        ?string $title = null,
+        ?string $apiVersion = null,
+        ?string $serverUrl = null,
+        ?string $description = null,
+    ) {
+        $this->title = $title;
+        $this->apiVersion = $apiVersion;
+        $this->serverUrl = $serverUrl;
+        $this->description = $description;
+    }
+
+    /**
+     * Add extra directories to scan beyond the default controllers dir.
+     *
+     * @param string ...$paths
+     * @return $this
+     */
+    public function addPaths(string ...$paths): self
+    {
+        $this->extraPaths = array_merge($this->extraPaths, $paths);
+        return $this;
+    }
+
+    /**
+     * Set the OpenAPI spec version.
+     *
+     * @param string $version e.g. "3.0.0" or "3.1.0".
+     * @return $this
+     */
+    public function setSpecVersion(string $version): self
+    {
+        $this->specVersion = $version;
+        return $this;
+    }
+
+    /**
+     * Generate the OpenAPI spec as a JSON string.
+     *
+     * Scans app/controllers/ (and any extra paths) for PHP 8 #[OA\...] attributes.
+     *
+     * @return string JSON-encoded OpenAPI spec.
+     */
+    public function generate(): string
+    {
+        $paths = [SDF_APP_CONT];
+        if (!empty($this->extraPaths)) {
+            $paths = array_merge($paths, $this->extraPaths);
+        }
+
+        $generator = new Generator();
+
+        if ($this->specVersion !== null) {
+            $generator->setVersion($this->specVersion);
+        }
+
+        $openapi = $generator->scan($paths);
+
+        // Ensure openapi version
+        if ($openapi->openapi === Generator::UNDEFINED) {
+            $openapi->openapi = '3.0.0';
+        }
+
+        // Ensure Info annotation (may be UNDEFINED when no #[OA\Info] attribute exists)
+        $info = $openapi->info;
+        if (!is_object($info) || $info === Generator::UNDEFINED) {
+            $info = new Info([]);
+            $openapi->info = $info;
+        }
+        $info->title = $this->title ?? ($info->title !== Generator::UNDEFINED ? $info->title : 'SDF API');
+        $info->version = $this->apiVersion ?? ($info->version !== Generator::UNDEFINED ? $info->version : '1.0.0');
+        if ($this->description !== null) {
+            $info->description = $this->description;
+        }
+
+        // Ensure Paths
+        if (!is_array($openapi->paths) || $openapi->paths === Generator::UNDEFINED) {
+            $openapi->paths = [];
+        }
+
+        // Set server URL
+        $serverUrl = $this->serverUrl ?? $this->detectServerUrl();
+        $openapi->servers = [
+            new Server([
+                'url' => $serverUrl,
+                'description' => 'SDF API server',
+            ]),
+        ];
+
+        return $openapi->toJson();
+    }
+
+    /**
+     * Generate the spec and decode to an array.
+     *
+     * @return array
+     */
+    public function generateArray(): array
+    {
+        return json_decode($this->generate(), true);
+    }
+
+    /**
+     * Detect the server URL from the current request.
+     *
+     * @return string
+     */
+    private function detectServerUrl(): string
+    {
+        $scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http';
+        $host = $_SERVER['HTTP_HOST'] ?? 'localhost';
+
+        return $scheme . '://' . $host;
+    }
+}

--- a/sdf/core/Validation/Validator.php
+++ b/sdf/core/Validation/Validator.php
@@ -1,0 +1,232 @@
+<?php
+
+/**
+ * smskSoft SDF Validation
+ * Copyright devsimsek
+ * @package     SDF
+ * @subpackage  SDF Validation
+ * @file        Validator.php
+ * @version     v1.0.0
+ * @author      devsimsek
+ * @copyright   Copyright (c) 2024, smskSoft, devsimsek
+ * @license     https://opensource.org/licenses/MIT MIT License
+ * @url         https://github.com/devsimsek/project-sdf/wiki/libraries/validation.md
+ * @since       Version 2.1
+ * @filesource
+ */
+
+declare(strict_types=1);
+
+namespace SDF\Validation;
+
+class Validator
+{
+    private array $data;
+    private array $rules;
+    private array $messages = [];
+    private array $customMessages = [];
+    private array $aliases = [];
+    private array $customRules = [];
+    private bool $passes = true;
+
+    public function __construct(array $data, array $rules)
+    {
+        $this->data = $data;
+        $this->rules = $rules;
+    }
+
+    public static function make(array $data, array $rules): self
+    {
+        return new self($data, $rules);
+    }
+
+    public function validate(): bool
+    {
+        $this->messages = [];
+        $this->passes = true;
+
+        foreach ($this->rules as $field => $fieldRules) {
+            $fieldRules = is_string($fieldRules) ? explode('|', $fieldRules) : $fieldRules;
+            $value = $this->data[$field] ?? null;
+
+            $this->validateField($field, $value, $fieldRules);
+        }
+
+        return $this->passes;
+    }
+
+    public function passes(): bool
+    {
+        return $this->passes;
+    }
+
+    public function fails(): bool
+    {
+        return !$this->passes;
+    }
+
+    public function errors(): array
+    {
+        return $this->messages;
+    }
+
+    public function setAliases(array $aliases): self
+    {
+        $this->aliases = $aliases;
+        return $this;
+    }
+
+    public function setMessages(array $messages): self
+    {
+        $this->customMessages = $messages;
+        return $this;
+    }
+
+    public function addRule(string $name, callable $callback): self
+    {
+        $this->customRules[$name] = $callback;
+        return $this;
+    }
+
+    private function validateField(string $field, mixed $value, array $rules): void
+    {
+        $hasNullable = in_array('nullable', $rules, true);
+
+        if ($hasNullable && ($value === null || $value === '')) {
+            return;
+        }
+
+        foreach ($rules as $ruleDef) {
+            [$rule, $params] = $this->parseRule($ruleDef);
+
+            if ($rule === 'nullable') {
+                continue;
+            }
+
+            $valid = $this->validateRule($field, $value, $rule, $params);
+
+            if (!$valid) {
+                $this->passes = false;
+                $this->addError($field, $rule, $params);
+            }
+        }
+    }
+
+    private function parseRule(string $rule): array
+    {
+        if (str_contains($rule, ':')) {
+            $parts = explode(':', $rule, 2);
+            return [$parts[0], explode(',', $parts[1])];
+        }
+        return [$rule, []];
+    }
+
+    private function validateRule(string $field, mixed $value, string $rule, array $params): bool
+    {
+        if (isset($this->customRules[$rule])) {
+            return (bool)($this->customRules[$rule])($value, $params, $this->data);
+        }
+
+        return match ($rule) {
+            'required' => $value !== null && $value !== '',
+            'email' => is_string($value) && filter_var($value, FILTER_VALIDATE_EMAIL) !== false,
+            'min' => $this->validateMin($value, $params),
+            'max' => $this->validateMax($value, $params),
+            'between' => $this->validateBetween($value, $params),
+            'numeric' => is_numeric($value),
+            'integer' => filter_var($value, FILTER_VALIDATE_INT) !== false,
+            'string' => is_string($value),
+            'boolean' => in_array($value, [true, false, 1, 0, '1', '0', 'true', 'false'], true),
+            'array' => is_array($value),
+            'alpha' => is_string($value) && ctype_alpha($value),
+            'alpha_num' => is_string($value) && ctype_alnum($value),
+            'url' => is_string($value) && filter_var($value, FILTER_VALIDATE_URL) !== false,
+            'in' => in_array((string)$value, $params, true),
+            'confirmed' => isset($this->data["{$field}_confirmation"]) && (string)$value === (string)$this->data["{$field}_confirmation"],
+            'same' => isset($params[0]) && isset($this->data[$params[0]]) && (string)$value === (string)$this->data[$params[0]],
+            'different' => isset($params[0]) && (!isset($this->data[$params[0]]) || (string)$value !== (string)$this->data[$params[0]]),
+            'regex' => isset($params[0]) && is_string($value) && preg_match($params[0], $value) === 1,
+            default => true,
+        };
+    }
+
+    private function validateMin(mixed $value, array $params): bool
+    {
+        if (!isset($params[0])) {
+            return true;
+        }
+        $min = (int)$params[0];
+        if (is_string($value)) {
+            return mb_strlen($value) >= $min;
+        }
+        if (is_numeric($value)) {
+            return (float)$value >= $min;
+        }
+        if (is_array($value)) {
+            return count($value) >= $min;
+        }
+        return false;
+    }
+
+    private function validateMax(mixed $value, array $params): bool
+    {
+        if (!isset($params[0])) {
+            return true;
+        }
+        $max = (int)$params[0];
+        if (is_string($value)) {
+            return mb_strlen($value) <= $max;
+        }
+        if (is_numeric($value)) {
+            return (float)$value <= $max;
+        }
+        if (is_array($value)) {
+            return count($value) <= $max;
+        }
+        return false;
+    }
+
+    private function validateBetween(mixed $value, array $params): bool
+    {
+        if (!isset($params[1])) {
+            return true;
+        }
+        return $this->validateMin($value, [$params[0]]) && $this->validateMax($value, [$params[1]]);
+    }
+
+    private function addError(string $field, string $rule, array $params): void
+    {
+        $message = $this->customMessages["{$field}.{$rule}"]
+            ?? $this->customMessages[$field]
+            ?? $this->defaultMessage($field, $rule, $params);
+
+        $this->messages[$field][] = $message;
+    }
+
+    private function defaultMessage(string $field, string $rule, array $params): string
+    {
+        $label = $this->aliases[$field] ?? str_replace('_', ' ', $field);
+
+        return match ($rule) {
+            'required' => "The {$label} field is required.",
+            'email' => "The {$label} must be a valid email address.",
+            'min' => "The {$label} must be at least {$params[0]}.",
+            'max' => "The {$label} must not exceed {$params[0]}.",
+            'between' => "The {$label} must be between {$params[0]} and {$params[1]}.",
+            'numeric' => "The {$label} must be a number.",
+            'integer' => "The {$label} must be an integer.",
+            'string' => "The {$label} must be a string.",
+            'boolean' => "The {$label} must be true or false.",
+            'array' => "The {$label} must be an array.",
+            'alpha' => "The {$label} may only contain letters.",
+            'alpha_num' => "The {$label} may only contain letters and numbers.",
+            'url' => "The {$label} must be a valid URL.",
+            'in' => "The selected {$label} is invalid.",
+            'confirmed' => "The {$label} confirmation does not match.",
+            'same' => "The {$label} must match {$params[0]}.",
+            'different' => "The {$label} must differ from {$params[0]}.",
+            'regex' => "The {$label} format is invalid.",
+            default => "The {$label} field is invalid.",
+        };
+    }
+}

--- a/sdf/core/helpers.php
+++ b/sdf/core/helpers.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * SDF Global Helper Functions
+ *
+ * @package     SDF
+ * @subpackage  SDF Core
+ * @filesource
+ */
+
+if (!function_exists('env')) {
+    /**
+     * Get an environment variable via SDF\Env.
+     *
+     * @param string     $key
+     * @param mixed|null $default
+     * @return mixed
+     */
+    function env(string $key, mixed $default = null): mixed
+    {
+        return \SDF\Env::get($key, $default);
+    }
+}
+
+if (!function_exists('csrf_token')) {
+    /**
+     * Get the current CSRF token (generates one if missing).
+     *
+     * @return string
+     */
+    function csrf_token(): string
+    {
+        return \SDF\Middleware\CsrfMiddleware::token();
+    }
+}
+
+if (!function_exists('csrf_field')) {
+    /**
+     * Render a hidden CSRF token input field.
+     *
+     * @return string
+     */
+    function csrf_field(): string
+    {
+        return \SDF\Middleware\CsrfMiddleware::field();
+    }
+}

--- a/sdf/core/helpers.php
+++ b/sdf/core/helpers.php
@@ -26,11 +26,12 @@ if (!function_exists('csrf_token')) {
     /**
      * Get the current CSRF token (generates one if missing).
      *
+     * @param string $sessionKey Session key (default: '_csrf_token').
      * @return string
      */
-    function csrf_token(): string
+    function csrf_token(string $sessionKey = '_csrf_token'): string
     {
-        return \SDF\Middleware\CsrfMiddleware::token();
+        return \SDF\Middleware\CsrfMiddleware::token($sessionKey);
     }
 }
 
@@ -38,10 +39,11 @@ if (!function_exists('csrf_field')) {
     /**
      * Render a hidden CSRF token input field.
      *
+     * @param string $sessionKey Session key (default: '_csrf_token').
      * @return string
      */
-    function csrf_field(): string
+    function csrf_field(string $sessionKey = '_csrf_token'): string
     {
-        return \SDF\Middleware\CsrfMiddleware::field();
+        return \SDF\Middleware\CsrfMiddleware::field($sessionKey);
     }
 }

--- a/sdf/warmup.php
+++ b/sdf/warmup.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * SDF Opcache Warmup Script
  * Run after deploy to pre-compile framework files into shared memory.

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -1,0 +1,448 @@
+<?php
+
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use SDF\Auth\Auth;
+use SDF\Auth\AuthMiddleware;
+use SDF\Auth\Guard;
+use SDF\Auth\JwtGuard;
+use SDF\Auth\SessionGuard;
+use SDF\Auth\UserProvider;
+use SDF\Core;
+use SDF\HttpResponseException;
+use SDF\Request;
+
+/**
+ * Stub user model for auth testing.
+ *
+ * Mimics the Spark\Model static API (find(), where()->first())
+ * with a simple in-memory store.
+ */
+class AuthTestUser
+{
+    public int $id;
+    public string $email;
+    public string $password;
+    public string $name;
+
+    /** @var array<int, AuthTestUser> In-memory store. */
+    private static array $store = [];
+
+    public function __construct(array $attributes = [])
+    {
+        foreach ($attributes as $key => $value) {
+            $this->$key = $value;
+        }
+    }
+
+    public static function resetStore(): void
+    {
+        self::$store = [];
+    }
+
+    public static function seed(array $data): self
+    {
+        $user = new self($data);
+        self::$store[$user->id] = $user;
+        return $user;
+    }
+
+    public static function find(mixed $id): ?self
+    {
+        return self::$store[$id] ?? null;
+    }
+
+    public static function where(string $column, mixed $value): object
+    {
+        return new class($column, $value, self::$store) {
+            private string $column;
+            private mixed $value;
+            private array $store;
+
+            public function __construct(string $c, mixed $v, array $s)
+            {
+                $this->column = $c;
+                $this->value = $v;
+                $this->store = $s;
+            }
+
+            public function first(): ?object
+            {
+                foreach ($this->store as $user) {
+                    if (($user->{$this->column} ?? null) === $this->value) {
+                        return $user;
+                    }
+                }
+                return null;
+            }
+        };
+    }
+}
+
+class AuthTest extends TestCase
+{
+    private string $tmpDir;
+
+    protected function setUp(): void
+    {
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
+        $_SESSION = [];
+
+        Auth::reset();
+        AuthTestUser::resetStore();
+
+        $this->tmpDir = sys_get_temp_dir() . '/sdf_auth_test_' . uniqid();
+        mkdir($this->tmpDir, 0755, true);
+
+        $this->setStaticProperty(Core::class, 'config', [
+            'auth' => [
+                'default' => 'session',
+                'guards' => [
+                    'session' => ['provider' => 'users'],
+                    'jwt' => [
+                        'provider' => 'users',
+                        'secret' => 'test-secret-key',
+                        'ttl' => 3600,
+                        'refresh_ttl' => 604800,
+                    ],
+                ],
+                'providers' => [
+                    'users' => ['model' => AuthTestUser::class],
+                ],
+            ],
+        ]);
+
+        AuthTestUser::seed([
+            'id' => 1,
+            'email' => 'alice@example.com',
+            'password' => password_hash('secret123', PASSWORD_BCRYPT),
+            'name' => 'Alice',
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        Auth::reset();
+        AuthTestUser::resetStore();
+        $this->setStaticProperty(Core::class, 'config', []);
+        $this->removeDirectory($this->tmpDir);
+        $_SESSION = [];
+    }
+
+    // ─── SessionGuard ─────────────────────────────────────────────────────────
+
+    public function test_session_guard_check_returns_false_when_not_authenticated(): void
+    {
+        $this->assertFalse(Auth::guard('session')->check());
+    }
+
+    public function test_session_guard_user_returns_null_when_not_authenticated(): void
+    {
+        $this->assertNull(Auth::guard('session')->user());
+    }
+
+    public function test_session_guard_login_and_check(): void
+    {
+        $user = AuthTestUser::find(1);
+        Auth::guard('session')->login($user);
+        $this->assertTrue(Auth::guard('session')->check());
+    }
+
+    public function test_session_guard_user_returns_hydrated_model(): void
+    {
+        $user = AuthTestUser::find(1);
+        Auth::guard('session')->login($user);
+        $retrieved = Auth::guard('session')->user();
+        $this->assertInstanceOf(AuthTestUser::class, $retrieved);
+        $this->assertSame('alice@example.com', $retrieved->email);
+    }
+
+    public function test_session_guard_logout_clears_state(): void
+    {
+        $user = AuthTestUser::find(1);
+        Auth::guard('session')->login($user);
+        Auth::guard('session')->logout();
+        $this->assertFalse(Auth::guard('session')->check());
+        $this->assertNull(Auth::guard('session')->user());
+    }
+
+    public function test_session_guard_attempt_with_valid_credentials(): void
+    {
+        $result = Auth::guard('session')->attempt([
+            'email' => 'alice@example.com',
+            'password' => 'secret123',
+        ]);
+        $this->assertTrue($result);
+        $this->assertTrue(Auth::guard('session')->check());
+    }
+
+    public function test_session_guard_attempt_with_invalid_password(): void
+    {
+        $result = Auth::guard('session')->attempt([
+            'email' => 'alice@example.com',
+            'password' => 'wrong',
+        ]);
+        $this->assertFalse($result);
+        $this->assertFalse(Auth::guard('session')->check());
+    }
+
+    public function test_session_guard_attempt_with_unknown_user(): void
+    {
+        $result = Auth::guard('session')->attempt([
+            'email' => 'bob@example.com',
+            'password' => 'secret123',
+        ]);
+        $this->assertFalse($result);
+    }
+
+    // ─── JwtGuard ─────────────────────────────────────────────────────────────
+
+    public function test_jwt_guard_check_returns_false_without_token(): void
+    {
+        $_SERVER['HTTP_AUTHORIZATION'] = '';
+        $this->assertFalse(Auth::guard('jwt')->check());
+    }
+
+    public function test_jwt_guard_issue_token_and_authenticate(): void
+    {
+        $user = AuthTestUser::find(1);
+        $guard = Auth::guard('jwt');
+
+        if (!$guard instanceof JwtGuard) {
+            $this->fail('Expected JwtGuard');
+        }
+
+        $token = $guard->issueToken($user);
+        $this->assertIsString($token);
+        $this->assertStringContainsString('.', $token);
+
+        $_SERVER['HTTP_AUTHORIZATION'] = "Bearer $token";
+        $this->assertTrue($guard->check());
+        $this->assertSame(1, $guard->user()->id);
+    }
+
+    public function test_jwt_guard_rejects_expired_token(): void
+    {
+        $guard = Auth::guard('jwt');
+
+        if (!$guard instanceof JwtGuard) {
+            $this->fail('Expected JwtGuard');
+        }
+
+        $token = $guard->encode([
+            'sub' => 1,
+            'iat' => time() - 7200,
+            'exp' => time() - 3600,
+            'type' => 'access',
+        ]);
+
+        $_SERVER['HTTP_AUTHORIZATION'] = "Bearer $token";
+        $this->assertFalse($guard->check());
+    }
+
+    public function test_jwt_guard_rejects_tampered_token(): void
+    {
+        $user = AuthTestUser::find(1);
+        $guard = Auth::guard('jwt');
+
+        if (!$guard instanceof JwtGuard) {
+            $this->fail('Expected JwtGuard');
+        }
+
+        $token = $guard->issueToken($user);
+        $tampered = substr($token, 0, -5) . 'XXXXX';
+
+        $_SERVER['HTTP_AUTHORIZATION'] = "Bearer $tampered";
+        $this->assertFalse($guard->check());
+    }
+
+    public function test_jwt_guard_login_and_user(): void
+    {
+        $guard = Auth::guard('jwt');
+
+        if (!$guard instanceof JwtGuard) {
+            $this->fail('Expected JwtGuard');
+        }
+
+        $user = AuthTestUser::find(1);
+        $guard->login($user);
+        $this->assertTrue($guard->check());
+        $this->assertSame(1, $guard->user()->id);
+    }
+
+    public function test_jwt_guard_logout(): void
+    {
+        $guard = Auth::guard('jwt');
+        $guard->login(AuthTestUser::find(1));
+        $guard->logout();
+        $this->assertFalse($guard->check());
+    }
+
+    public function test_jwt_guard_attempt(): void
+    {
+        $guard = Auth::guard('jwt');
+        $result = $guard->attempt([
+            'email' => 'alice@example.com',
+            'password' => 'secret123',
+        ]);
+        $this->assertTrue($result);
+    }
+
+    // ─── JWT Refresh ───────────────────────────────────────────────────────────
+
+    public function test_jwt_guard_issue_and_verify_refresh_token(): void
+    {
+        $guard = Auth::guard('jwt');
+
+        if (!$guard instanceof JwtGuard) {
+            $this->fail('Expected JwtGuard');
+        }
+
+        $user = AuthTestUser::find(1);
+        $refreshToken = $guard->issueRefreshToken($user);
+        $this->assertIsString($refreshToken);
+
+        $result = $guard->refresh($refreshToken);
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('access_token', $result);
+        $this->assertArrayHasKey('refresh_token', $result);
+        $this->assertSame('Bearer', $result['token_type']);
+
+        // New access token should authenticate
+        $_SERVER['HTTP_AUTHORIZATION'] = 'Bearer ' . $result['access_token'];
+        $this->assertTrue($guard->check());
+    }
+
+    public function test_jwt_guard_refresh_rejects_expired_token(): void
+    {
+        $guard = Auth::guard('jwt');
+
+        if (!$guard instanceof JwtGuard) {
+            $this->fail('Expected JwtGuard');
+        }
+
+        $expiredRefresh = $guard->encode([
+            'sub' => 1,
+            'iat' => time() - 700000,
+            'exp' => time() - 3600,
+            'type' => 'refresh',
+        ]);
+
+        $this->assertNull($guard->refresh($expiredRefresh));
+    }
+
+    public function test_jwt_guard_refresh_rejects_access_token(): void
+    {
+        $guard = Auth::guard('jwt');
+
+        if (!$guard instanceof JwtGuard) {
+            $this->fail('Expected JwtGuard');
+        }
+
+        $user = AuthTestUser::find(1);
+        $accessToken = $guard->issueToken($user);
+        $this->assertNull($guard->refresh($accessToken));
+    }
+
+    // ─── Auth Facade ───────────────────────────────────────────────────────────
+
+    public function test_auth_facade_check_delegates_to_default_guard(): void
+    {
+        $this->assertFalse(Auth::check());
+        Auth::login(AuthTestUser::find(1));
+        $this->assertTrue(Auth::check());
+    }
+
+    public function test_auth_facade_user_returns_authenticated_user(): void
+    {
+        Auth::login(AuthTestUser::find(1));
+        $user = Auth::user();
+        $this->assertInstanceOf(AuthTestUser::class, $user);
+        $this->assertSame('alice@example.com', $user->email);
+    }
+
+    public function test_auth_facade_logout(): void
+    {
+        Auth::login(AuthTestUser::find(1));
+        Auth::logout();
+        $this->assertFalse(Auth::check());
+    }
+
+    public function test_auth_facade_attempt(): void
+    {
+        $result = Auth::attempt([
+            'email' => 'alice@example.com',
+            'password' => 'secret123',
+        ]);
+        $this->assertTrue($result);
+    }
+
+    public function test_auth_facade_issue_token_returns_null_for_session_guard(): void
+    {
+        $this->assertNull(Auth::issueToken(AuthTestUser::find(1)));
+    }
+
+    public function test_auth_facade_refresh_returns_null_for_session_guard(): void
+    {
+        $this->assertNull(Auth::refresh('some-token'));
+    }
+
+    // ─── AuthMiddleware ────────────────────────────────────────────────────────
+
+    public function test_auth_middleware_passes_when_authenticated(): void
+    {
+        Auth::login(AuthTestUser::find(1));
+        $request = new Request();
+
+        $middleware = new AuthMiddleware('session');
+        $response = $middleware->handle($request, function ($req) {
+            return 'allowed';
+        });
+        $this->assertSame('allowed', $response);
+    }
+
+    public function test_auth_middleware_throws_401_when_not_authenticated(): void
+    {
+        $request = new Request();
+        $middleware = new AuthMiddleware('session');
+
+        $this->expectException(HttpResponseException::class);
+        $this->expectExceptionMessage('Unauthenticated');
+
+        $middleware->handle($request, function ($req) {
+            return 'should not reach';
+        });
+    }
+
+    // ─── Helpers ───────────────────────────────────────────────────────────────
+
+    private function setStaticProperty(string $class, string $property, mixed $value): void
+    {
+        $ref = new ReflectionClass($class);
+        $prop = $ref->getProperty($property);
+        $prop->setValue(null, $value);
+    }
+
+    private function removeDirectory(string $directory): void
+    {
+        if (!is_dir($directory)) {
+            return;
+        }
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($directory, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        foreach ($items as $item) {
+            if ($item->isDir()) {
+                rmdir($item->getRealPath());
+            } else {
+                unlink($item->getRealPath());
+            }
+        }
+        rmdir($directory);
+    }
+}

--- a/tests/CorsTest.php
+++ b/tests/CorsTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * SDF CORS Middleware tests.
+ *
+ * @package     Tests
+ * @file        CorsTest.php
+ * @author      devsimsek
+ * @copyright   Copyright (c) 2022-2026, smskSoft, devsimsek
+ * @license     https://opensource.org/licenses/MIT MIT License
+ */
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+use SDF\Core;
+use SDF\Middleware\CorsMiddleware;
+use ReflectionClass;
+
+class CorsTest extends TestCase
+{
+    private CorsMiddleware $middleware;
+
+    protected function setUp(): void
+    {
+        $this->middleware = new CorsMiddleware();
+    }
+
+    public function test_allows_wildcard_origin(): void
+    {
+        $config = ['allowed_origins' => ['*']];
+        $ref = new ReflectionClass($this->middleware);
+        $method = $ref->getMethod('isOriginAllowed');
+
+        $this->assertTrue($method->invoke($this->middleware, 'http://example.com', $config));
+        $this->assertTrue($method->invoke($this->middleware, 'http://evil.com', $config));
+    }
+
+    public function test_allows_specific_origin(): void
+    {
+        $config = ['allowed_origins' => ['http://trusted.com']];
+        $ref = new ReflectionClass($this->middleware);
+        $method = $ref->getMethod('isOriginAllowed');
+
+        $this->assertTrue($method->invoke($this->middleware, 'http://trusted.com', $config));
+        $this->assertFalse($method->invoke($this->middleware, 'http://evil.com', $config));
+    }
+
+    public function test_allows_pattern_origin(): void
+    {
+        $config = [
+            'allowed_origins_patterns' => ['/^https:\/\/.*\.trusted\.com$/'],
+        ];
+        $ref = new ReflectionClass($this->middleware);
+        $method = $ref->getMethod('isOriginAllowed');
+
+        $this->assertTrue($method->invoke($this->middleware, 'https://app.trusted.com', $config));
+        $this->assertFalse($method->invoke($this->middleware, 'https://evil.com', $config));
+    }
+
+    public function test_getConfig_returns_defaults(): void
+    {
+        $ref = new ReflectionClass($this->middleware);
+        $method = $ref->getMethod('getConfig');
+
+        $config = $method->invoke($this->middleware);
+        $this->assertIsArray($config);
+        $this->assertArrayHasKey('allowed_origins', $config);
+        $this->assertArrayHasKey('allowed_methods', $config);
+        $this->assertArrayHasKey('allowed_headers', $config);
+    }
+
+    public function test_preflight_sets_headers(): void
+    {
+        $config = ['allowed_origins' => ['*'], 'allowed_methods' => ['GET'], 'allowed_headers' => ['X-CSRF-TOKEN'], 'max_age' => 3600];
+        $ref = new ReflectionClass($this->middleware);
+        $method = $ref->getMethod('setPreflightHeaders');
+
+        $method->invoke($this->middleware, '*', $config);
+        $this->assertTrue(true);
+    }
+}

--- a/tests/CsrfTest.php
+++ b/tests/CsrfTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * SDF CSRF Middleware tests.
+ *
+ * @package     Tests
+ * @file        CsrfTest.php
+ * @author      devsimsek
+ * @copyright   Copyright (c) 2022-2026, smskSoft, devsimsek
+ * @license     https://opensource.org/licenses/MIT MIT License
+ */
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use SDF\Middleware\CsrfMiddleware;
+use SDF\Session;
+
+class CsrfTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
+        $_SESSION = [];
+
+        $ref = new ReflectionClass(Session::class);
+        $prop = $ref->getProperty('instance');
+        $prop->setValue(null, null);
+    }
+
+    protected function tearDown(): void
+    {
+        $_SESSION = [];
+    }
+
+    public function test_generates_token(): void
+    {
+        $token = CsrfMiddleware::generateToken();
+        $this->assertSame(64, strlen($token));
+    }
+
+    public function test_token_is_stored_in_session(): void
+    {
+        $token = CsrfMiddleware::generateToken();
+        $this->assertSame($token, Session::getInstance()->get('_csrf_token'));
+    }
+
+    public function test_token_returns_same_within_session(): void
+    {
+        $a = CsrfMiddleware::token();
+        $b = CsrfMiddleware::token();
+        $this->assertSame($a, $b);
+    }
+
+    public function test_field_returns_hidden_input(): void
+    {
+        $token = CsrfMiddleware::token();
+        $field = CsrfMiddleware::field();
+        $this->assertStringContainsString('_token', $field);
+        $this->assertStringContainsString($token, $field);
+    }
+}

--- a/tests/EncryptionTest.php
+++ b/tests/EncryptionTest.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * SDF Encryption tests.
+ *
+ * @package     Tests
+ * @file        EncryptionTest.php
+ * @author      devsimsek
+ * @copyright   Copyright (c) 2022-2026, smskSoft, devsimsek
+ * @license     https://opensource.org/licenses/MIT MIT License
+ */
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+use SDF\Encryption\Encrypter;
+
+class EncryptionTest extends TestCase
+{
+    private Encrypter $encrypter;
+    private string $rawKey;
+
+    protected function setUp(): void
+    {
+        $this->rawKey = random_bytes(32);
+        $this->encrypter = new Encrypter($this->rawKey);
+    }
+
+    public function test_encrypt_and_decrypt(): void
+    {
+        $plain = 'secret data';
+        $encrypted = $this->encrypter->encrypt($plain);
+        $this->assertNotSame($plain, $encrypted);
+        $this->assertSame($plain, $this->encrypter->decrypt($encrypted));
+    }
+
+    public function test_encrypt_returns_base64(): void
+    {
+        $encrypted = $this->encrypter->encrypt('test');
+        $this->assertMatchesRegularExpression('/^[A-Za-z0-9+\/=]+$/', $encrypted);
+    }
+
+    public function test_different_ciphertexts_per_call(): void
+    {
+        $a = $this->encrypter->encrypt('same');
+        $b = $this->encrypter->encrypt('same');
+        $this->assertNotSame($a, $b);
+    }
+
+    public function test_decrypt_with_wrong_key_fails(): void
+    {
+        $encrypted = $this->encrypter->encrypt('secret');
+        $wrong = new Encrypter(random_bytes(32));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Decryption failed');
+        $wrong->decrypt($encrypted);
+    }
+
+    public function test_decrypt_invalid_payload(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Invalid encrypted payload');
+        $this->encrypter->decrypt('not-valid-base64!!!');
+    }
+
+    public function test_base64_encoded_key(): void
+    {
+        $b64 = base64_encode($this->rawKey);
+        $enc = new Encrypter($b64);
+        $cipher = $enc->encrypt('test');
+        $this->assertSame('test', $enc->decrypt($cipher));
+    }
+
+    public function test_short_key_throws(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('32 bytes');
+        new Encrypter('too-short');
+    }
+
+    public function test_encrypts_empty_string(): void
+    {
+        $encrypted = $this->encrypter->encrypt('');
+        $this->assertSame('', $this->encrypter->decrypt($encrypted));
+    }
+
+    public function test_encrypts_unicode(): void
+    {
+        $plain = 'héllo wörld 🔐';
+        $encrypted = $this->encrypter->encrypt($plain);
+        $this->assertSame($plain, $this->encrypter->decrypt($encrypted));
+    }
+
+    public function test_fromConfig_throws_when_key_missing(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Encryption key not configured');
+        Encrypter::fromConfig();
+    }
+}

--- a/tests/EnvTest.php
+++ b/tests/EnvTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * SDF Environment (.env) tests.
+ *
+ * @package     Tests
+ * @file        EnvTest.php
+ * @author      devsimsek
+ * @copyright   Copyright (c) 2022-2026, smskSoft, devsimsek
+ * @license     https://opensource.org/licenses/MIT MIT License
+ */
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+use SDF\Env;
+
+class EnvTest extends TestCase
+{
+    private string $tmpFile;
+
+    protected function setUp(): void
+    {
+        Env::reset();
+        $this->tmpFile = tempnam(sys_get_temp_dir(), 'env_');
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->tmpFile);
+        Env::reset();
+    }
+
+    public function test_loads_simple_key_value(): void
+    {
+        file_put_contents($this->tmpFile, "FOO=bar");
+        Env::load($this->tmpFile);
+        $this->assertSame('bar', Env::get('FOO'));
+    }
+
+    public function test_loads_quoted_value(): void
+    {
+        file_put_contents($this->tmpFile, 'FOO="bar baz"');
+        Env::load($this->tmpFile);
+        $this->assertSame('bar baz', Env::get('FOO'));
+    }
+
+    public function test_loads_single_quoted_value(): void
+    {
+        file_put_contents($this->tmpFile, "FOO='bar baz'");
+        Env::load($this->tmpFile);
+        $this->assertSame('bar baz', Env::get('FOO'));
+    }
+
+    public function test_strips_inline_comment(): void
+    {
+        file_put_contents($this->tmpFile, 'FOO=bar # this is a comment');
+        Env::load($this->tmpFile);
+        $this->assertSame('bar', Env::get('FOO'));
+    }
+
+    public function test_skips_comment_lines(): void
+    {
+        file_put_contents($this->tmpFile, "# comment\nFOO=bar");
+        Env::load($this->tmpFile);
+        $this->assertSame('bar', Env::get('FOO'));
+    }
+
+    public function test_resolves_placeholder(): void
+    {
+        file_put_contents($this->tmpFile, "APP_NAME=MyApp\nFOO=hello-\${APP_NAME}");
+        Env::load($this->tmpFile);
+        $this->assertSame('hello-MyApp', Env::get('FOO'));
+    }
+
+    public function test_returns_default_on_missing(): void
+    {
+        $this->assertSame('default', Env::get('MISSING', 'default'));
+    }
+
+    public function test_set_puts_value(): void
+    {
+        Env::set('DYNAMIC', 'value');
+        $this->assertSame('value', Env::get('DYNAMIC'));
+    }
+
+    public function test_has_returns_bool(): void
+    {
+        Env::set('EXISTS', 'yes');
+        $this->assertTrue(Env::has('EXISTS'));
+        $this->assertFalse(Env::has('NONEXIST'));
+    }
+
+    public function test_global_env_helper(): void
+    {
+        Env::set('HELPER_TEST', 'works');
+        $this->assertSame('works', \env('HELPER_TEST'));
+    }
+
+    public function test_skips_missing_file(): void
+    {
+        Env::load('/tmp/__nonexistent_env_file__');
+        $this->assertNull(Env::get('ANYTHING'));
+    }
+}

--- a/tests/FlashTest.php
+++ b/tests/FlashTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use SDF\Flash;
+use SDF\Session;
+
+class FlashTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
+        $_SESSION = [];
+        $this->resetSessionInstance();
+    }
+
+    protected function tearDown(): void
+    {
+        $_SESSION = [];
+        $this->resetSessionInstance();
+    }
+
+    public function test_flash_set_and_get_across_requests(): void
+    {
+        // First request: set flash
+        $flash = new Flash();
+        $flash->set('success', 'Operation completed');
+
+        // Simulate next request: new Flash instance ages data
+        $flash2 = new Flash();
+        $this->assertSame('Operation completed', $flash2->get('success'));
+    }
+
+    public function test_flash_get_consumes_message(): void
+    {
+        $flash = new Flash();
+        $flash->set('key', 'value');
+
+        $flash2 = new Flash();
+        $this->assertSame('value', $flash2->get('key'));
+        $this->assertNull($flash2->get('key'));
+    }
+
+    public function test_flash_get_returns_default_on_miss(): void
+    {
+        $flash = new Flash();
+        $this->assertNull($flash->get('missing'));
+        $this->assertSame('fallback', $flash->get('missing', 'fallback'));
+    }
+
+    public function test_flash_has_without_consuming(): void
+    {
+        $flash = new Flash();
+        $flash->set('key', 'value');
+
+        $flash2 = new Flash();
+        $this->assertTrue($flash2->has('key'));
+        $this->assertTrue($flash2->has('key')); // has does not consume
+        $this->assertSame('value', $flash2->get('key'));
+    }
+
+    public function test_flash_all_returns_all_messages(): void
+    {
+        $flash = new Flash();
+        $flash->set('a', 1);
+        $flash->set('b', 2);
+
+        $flash2 = new Flash();
+        $this->assertSame(['a' => 1, 'b' => 2], $flash2->all());
+    }
+
+    public function test_flash_now_available_immediately(): void
+    {
+        $flash = new Flash();
+        $flash->now('alert', 'Instant message');
+        $this->assertSame('Instant message', $flash->get('alert'));
+    }
+
+    public function test_flash_now_does_not_persist(): void
+    {
+        $flash = new Flash();
+        $flash->now('alert', 'Instant');
+
+        $flash2 = new Flash();
+        $this->assertNull($flash2->get('alert'));
+    }
+
+    public function test_flash_keep_preserves_message(): void
+    {
+        $flash = new Flash();
+        $flash->set('key', 'value');
+
+        $flash2 = new Flash();
+        $flash2->keep('key'); // move back to new
+
+        $flash3 = new Flash();
+        $this->assertSame('value', $flash3->get('key'));
+    }
+
+    public function test_flash_set_is_fluent(): void
+    {
+        $flash = new Flash();
+        $result = $flash->set('key', 'value');
+        $this->assertSame($flash, $result);
+    }
+
+    public function test_flash_get_non_aged_message_returns_default(): void
+    {
+        // Message stored in _new should not be accessible via get()
+        // (it hasn't been aged yet — only available next request)
+        $flash = new Flash();
+        $flash->set('key', 'value');
+        $this->assertNull($flash->get('key'));
+    }
+
+    public function test_flash_accepts_session_instance(): void
+    {
+        $session = Session::getInstance();
+        $flash = new Flash($session);
+        $flash->set('key', 'value');
+
+        $flash2 = new Flash($session);
+        $this->assertSame('value', $flash2->get('key'));
+    }
+
+    private function resetSessionInstance(): void
+    {
+        $ref = new ReflectionClass(Session::class);
+        $prop = $ref->getProperty('instance');
+        $prop->setValue(null, null);
+    }
+}

--- a/tests/FlashTest.php
+++ b/tests/FlashTest.php
@@ -111,7 +111,7 @@ class FlashTest extends TestCase
     public function test_flash_get_non_aged_message_returns_default(): void
     {
         // Message stored in _new should not be accessible via get()
-        // (it hasn't been aged yet — only available next request)
+        // (it hasn't been aged yet - only available next request)
         $flash = new Flash();
         $flash->set('key', 'value');
         $this->assertNull($flash->get('key'));

--- a/tests/HttpMessageTest.php
+++ b/tests/HttpMessageTest.php
@@ -1,0 +1,464 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+use SDF\Http\ServerRequest;
+use SDF\Http\Stream;
+use SDF\Http\Uri;
+use SDF\Http\Response;
+use SDF\Http\UploadedFile;
+
+/**
+ * Tests for PSR-7 HTTP message implementations.
+ *
+ * @covers \SDF\Http\Stream
+ * @covers \SDF\Http\Uri
+ * @covers \SDF\Http\UploadedFile
+ * @covers \SDF\Http\Response
+ * @covers \SDF\Http\ServerRequest
+ */
+class HttpMessageTest extends TestCase
+{
+    // ─── Stream ───────────────────────────────────────────────────
+
+    public function test_stream_from_string(): void
+    {
+        $s = new Stream('hello world');
+        $this->assertSame('hello world', (string) $s);
+        $this->assertSame(11, $s->getSize());
+    }
+
+    public function test_stream_tell_seek_eof(): void
+    {
+        $s = new Stream('abcdef');
+        $this->assertSame(0, $s->tell());
+        $s->seek(3);
+        $this->assertSame(3, $s->tell());
+        $this->assertSame('def', $s->read(3));
+        // Read past end to trigger EOF flag on php://temp
+        $s->read(1);
+        $this->assertTrue($s->eof());
+    }
+
+    public function test_stream_is_readable_writable(): void
+    {
+        $s = new Stream('test');
+        $this->assertTrue($s->isReadable());
+        $this->assertTrue($s->isWritable());
+    }
+
+    public function test_stream_write(): void
+    {
+        $s = new Stream('', 'w+');
+        $s->write('hello');
+        $s->rewind();
+        $this->assertSame('hello', $s->getContents());
+    }
+
+    public function test_stream_get_metadata(): void
+    {
+        $s = new Stream('data');
+        $meta = $s->getMetadata();
+        $this->assertArrayHasKey('stream_type', $meta);
+        $this->assertNotNull($s->getMetadata('stream_type'));
+    }
+
+    public function test_stream_close_and_detach(): void
+    {
+        $s = new Stream('data');
+        $s->close();
+        $this->assertNull($s->getSize());
+        $this->assertFalse($s->isReadable());
+    }
+
+    public function test_stream_detach_returns_resource(): void
+    {
+        $s = new Stream('data');
+        $res = $s->detach();
+        $this->assertIsResource($res);
+        fclose($res);
+    }
+
+    // ─── Uri ──────────────────────────────────────────────────────
+
+    public function test_uri_parse_full(): void
+    {
+        $u = new Uri('https://user:pass@example.com:8080/path/to?foo=bar#frag');
+        $this->assertSame('https', $u->getScheme());
+        $this->assertSame('user:pass', $u->getUserInfo());
+        $this->assertSame('example.com', $u->getHost());
+        $this->assertSame(8080, $u->getPort());
+        $this->assertSame('/path/to', $u->getPath());
+        $this->assertSame('foo=bar', $u->getQuery());
+        $this->assertSame('frag', $u->getFragment());
+        $this->assertSame('user:pass@example.com:8080', $u->getAuthority());
+    }
+
+    public function test_uri_immutable_with_scheme(): void
+    {
+        $u = new Uri('http://example.com');
+        $u2 = $u->withScheme('https');
+        $this->assertNotSame($u, $u2);
+        $this->assertSame('https', $u2->getScheme());
+        $this->assertSame('http', $u->getScheme());
+    }
+
+    public function test_uri_immutable_with_host(): void
+    {
+        $u = new Uri('http://a.com');
+        $u2 = $u->withHost('b.com');
+        $this->assertSame('b.com', $u2->getHost());
+        $this->assertSame('a.com', $u->getHost());
+    }
+
+    public function test_uri_immutable_with_port(): void
+    {
+        $u = new Uri('http://example.com');
+        $u2 = $u->withPort(9090);
+        $this->assertSame(9090, $u2->getPort());
+        $this->assertNull($u2->withPort(null)->getPort());
+    }
+
+    public function test_uri_immutable_with_path(): void
+    {
+        $u = new Uri('http://example.com');
+        $u2 = $u->withPath('/new');
+        $this->assertSame('/new', $u2->getPath());
+    }
+
+    public function test_uri_immutable_with_query(): void
+    {
+        $u = new Uri('http://example.com');
+        $u2 = $u->withQuery('key=val');
+        $this->assertSame('key=val', $u2->getQuery());
+    }
+
+    public function test_uri_immutable_with_fragment(): void
+    {
+        $u = new Uri('http://example.com');
+        $u2 = $u->withFragment('sec');
+        $this->assertSame('sec', $u2->getFragment());
+    }
+
+    public function test_uri_standard_port_not_in_authority(): void
+    {
+        $u = new Uri('https://example.com:443/path');
+        $this->assertNull($u->getPort());
+        $this->assertSame('example.com', $u->getAuthority());
+    }
+
+    public function test_uri___toString(): void
+    {
+        $u = new Uri('https://user@example.com:8080/p?q=1#h');
+        $this->assertSame('https://user@example.com:8080/p?q=1#h', (string) $u);
+    }
+
+    // ─── UploadedFile ──────────────────────────────────────────────
+
+    public function test_uploaded_file_basics(): void
+    {
+        $file = new UploadedFile(__FILE__, \UPLOAD_ERR_OK, 'test.php', 'text/plain', 123);
+        $this->assertSame('test.php', $file->getClientFilename());
+        $this->assertSame('text/plain', $file->getClientMediaType());
+        $this->assertSame(123, $file->getSize());
+        $this->assertSame(\UPLOAD_ERR_OK, $file->getError());
+    }
+
+    public function test_uploaded_file_move(): void
+    {
+        $tmpDir = sys_get_temp_dir();
+        $tmpFile = tempnam($tmpDir, 'psr7_test_');
+        file_put_contents($tmpFile, 'uploaded content');
+
+        $file = new UploadedFile($tmpFile, \UPLOAD_ERR_OK);
+        $dest = $tmpDir . '/psr7_moved_' . uniqid();
+        $file->moveTo($dest);
+        $this->assertFileExists($dest);
+        $this->assertSame('uploaded content', file_get_contents($dest));
+        unlink($dest);
+    }
+
+    public function test_uploaded_file_get_stream(): void
+    {
+        $tmpFile = tempnam(sys_get_temp_dir(), 'psr7_');
+        file_put_contents($tmpFile, 'stream content');
+
+        $file = new UploadedFile($tmpFile, \UPLOAD_ERR_OK);
+        $stream = $file->getStream();
+        $this->assertSame('stream content', (string) $stream);
+        unlink($tmpFile);
+    }
+
+    // ─── Response ─────────────────────────────────────────────────
+
+    public function test_response_status_code(): void
+    {
+        $r = new Response(200);
+        $this->assertSame(200, $r->getStatusCode());
+        $this->assertSame('OK', $r->getReasonPhrase());
+    }
+
+    public function test_response_custom_reason_phrase(): void
+    {
+        $r = new Response(299, [], null, '1.1', 'Custom');
+        $this->assertSame('Custom', $r->getReasonPhrase());
+    }
+
+    public function test_response_with_status(): void
+    {
+        $r = new Response(200);
+        $r2 = $r->withStatus(404);
+        $this->assertNotSame($r, $r2);
+        $this->assertSame(404, $r2->getStatusCode());
+        $this->assertSame('Not Found', $r2->getReasonPhrase());
+    }
+
+    public function test_response_with_custom_reason(): void
+    {
+        $r = new Response(200);
+        $r2 = $r->withStatus(418, "I'm a teapot");
+        $this->assertSame("I'm a teapot", $r2->getReasonPhrase());
+    }
+
+    public function test_response_headers(): void
+    {
+        $r = new Response(200, ['X-Foo' => 'bar']);
+        $this->assertSame(['bar'], $r->getHeader('X-Foo'));
+        $this->assertTrue($r->hasHeader('X-Foo'));
+        $this->assertFalse($r->hasHeader('X-Missing'));
+        $this->assertSame('bar', $r->getHeaderLine('X-Foo'));
+    }
+
+    public function test_response_with_header(): void
+    {
+        $r = new Response();
+        $r2 = $r->withHeader('Content-Type', 'application/json');
+        $this->assertNotSame($r, $r2);
+        $this->assertSame(['application/json'], $r2->getHeader('Content-Type'));
+        $this->assertFalse($r->hasHeader('Content-Type'));
+    }
+
+    public function test_response_with_added_header(): void
+    {
+        $r = new Response(200, ['Set-Cookie' => 'a=1']);
+        $r2 = $r->withAddedHeader('Set-Cookie', 'b=2');
+        $this->assertSame(['a=1', 'b=2'], $r2->getHeader('Set-Cookie'));
+    }
+
+    public function test_response_without_header(): void
+    {
+        $r = new Response(200, ['X-Foo' => 'bar']);
+        $r2 = $r->withoutHeader('X-Foo');
+        $this->assertFalse($r2->hasHeader('X-Foo'));
+        $this->assertTrue($r->hasHeader('X-Foo'));
+    }
+
+    public function test_response_body(): void
+    {
+        $r = new Response(200, [], new Stream('body content'));
+        $this->assertSame('body content', (string) $r->getBody());
+    }
+
+    public function test_response_protocol_version(): void
+    {
+        $r = new Response(200, [], null, '2.0');
+        $this->assertSame('2.0', $r->getProtocolVersion());
+        $r2 = $r->withProtocolVersion('1.0');
+        $this->assertSame('1.0', $r2->getProtocolVersion());
+    }
+
+    // ─── ServerRequest ────────────────────────────────────────────
+
+    public function test_server_request_method_and_uri(): void
+    {
+        $r = new ServerRequest('POST', 'http://example.com/foo');
+        $this->assertSame('POST', $r->getMethod());
+        $this->assertSame('example.com', $r->getUri()->getHost());
+        $this->assertSame('/foo', $r->getUri()->getPath());
+    }
+
+    public function test_server_request_with_method(): void
+    {
+        $r = new ServerRequest('GET');
+        $r2 = $r->withMethod('DELETE');
+        $this->assertSame('DELETE', $r2->getMethod());
+        $this->assertSame('GET', $r->getMethod());
+    }
+
+    public function test_server_request_with_uri(): void
+    {
+        $r = new ServerRequest('GET', 'http://a.com');
+        $u = new Uri('http://b.com');
+        $r2 = $r->withUri($u);
+        $this->assertSame('b.com', $r2->getUri()->getHost());
+        $this->assertSame('a.com', $r->getUri()->getHost());
+    }
+
+    public function test_server_request_request_target(): void
+    {
+        $r = new ServerRequest('GET', 'http://example.com/path?q=1');
+        $this->assertSame('/path?q=1', $r->getRequestTarget());
+
+        $r2 = $r->withRequestTarget('*');
+        $this->assertSame('*', $r2->getRequestTarget());
+        $this->assertSame('/path?q=1', $r->getRequestTarget());
+    }
+
+    public function test_server_request_headers(): void
+    {
+        $r = new ServerRequest('GET', '', ['X-Custom' => ['val']]);
+        $this->assertSame(['val'], $r->getHeader('X-Custom'));
+        $this->assertSame('val', $r->getHeaderLine('X-Custom'));
+    }
+
+    public function test_server_request_immutable_headers(): void
+    {
+        $r = new ServerRequest();
+        $r2 = $r->withHeader('X-Foo', 'bar');
+        $r3 = $r2->withAddedHeader('X-Foo', 'baz');
+        $this->assertFalse($r->hasHeader('X-Foo'));
+        $this->assertSame(['bar'], $r2->getHeader('X-Foo'));
+        $this->assertSame(['bar', 'baz'], $r3->getHeader('X-Foo'));
+
+        $r4 = $r3->withoutHeader('X-Foo');
+        $this->assertFalse($r4->hasHeader('X-Foo'));
+        $this->assertTrue($r3->hasHeader('X-Foo'));
+    }
+
+    public function test_server_request_attributes(): void
+    {
+        $r = new ServerRequest();
+        $r2 = $r->withAttribute('role', 'admin');
+        $this->assertSame('admin', $r2->getAttribute('role'));
+        $this->assertNull($r->getAttribute('role'));
+        $this->assertSame('default', $r->getAttribute('missing', 'default'));
+
+        $r3 = $r2->withoutAttribute('role');
+        $this->assertNull($r3->getAttribute('role'));
+    }
+
+    public function test_server_request_server_params(): void
+    {
+        $r = new ServerRequest('GET', '', [], null, '1.1', ['REMOTE_ADDR' => '127.0.0.1']);
+        $this->assertSame('127.0.0.1', $r->getServerParams()['REMOTE_ADDR']);
+    }
+
+    public function test_server_request_parsed_body(): void
+    {
+        $r = new ServerRequest('POST');
+        $r2 = $r->withParsedBody(['key' => 'value']);
+        $this->assertSame(['key' => 'value'], $r2->getParsedBody());
+        $this->assertNull($r->getParsedBody());
+    }
+
+    public function test_server_request_query_params(): void
+    {
+        $r = new ServerRequest('GET');
+        $r2 = $r->withQueryParams(['page' => 2]);
+        $this->assertSame(['page' => 2], $r2->getQueryParams());
+    }
+
+    public function test_server_request_cookie_params(): void
+    {
+        $r = new ServerRequest('GET');
+        $r2 = $r->withCookieParams(['session' => 'abc']);
+        $this->assertSame(['session' => 'abc'], $r2->getCookieParams());
+    }
+
+    public function test_server_request_body(): void
+    {
+        $r = new ServerRequest('PUT', '', [], 'raw body');
+        $this->assertSame('raw body', (string) $r->getBody());
+    }
+
+    public function test_server_request_protocol_version(): void
+    {
+        $r = new ServerRequest('GET', '', [], null, '2.0');
+        $this->assertSame('2.0', $r->getProtocolVersion());
+    }
+
+    public function test_server_request_from_globals(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $_SERVER['HTTP_HOST'] = 'test.dev';
+        $_SERVER['REQUEST_URI'] = '/test?q=1';
+        $_GET = ['q' => '1'];
+        $_POST = [];
+        $_COOKIE = [];
+        $_FILES = [];
+
+        $r = ServerRequest::fromGlobals();
+        $this->assertSame('GET', $r->getMethod());
+        $this->assertSame('test.dev', $r->getUri()->getHost());
+        $this->assertSame('/test', $r->getUri()->getPath());
+        $this->assertSame(['q' => '1'], $r->getQueryParams());
+    }
+
+    public function test_server_request_uploaded_files(): void
+    {
+        $_FILES = [
+            'avatar' => [
+                'name' => 'photo.jpg',
+                'type' => 'image/jpeg',
+                'tmp_name' => '/tmp/phpXXX',
+                'error' => \UPLOAD_ERR_OK,
+                'size' => 12345,
+            ],
+        ];
+
+        $r = ServerRequest::fromGlobals();
+        $files = $r->getUploadedFiles();
+        $this->assertArrayHasKey('avatar', $files);
+        $this->assertInstanceOf(UploadedFile::class, $files['avatar']);
+        $this->assertSame('photo.jpg', $files['avatar']->getClientFilename());
+        $this->assertSame(12345, $files['avatar']->getSize());
+    }
+
+    // ─── Legacy bridge methods ────────────────────────────────────
+
+    public function test_legacy_request_to_psr(): void
+    {
+        $req = new \SDF\Request();
+        $psr = $req->toPsr();
+        $this->assertInstanceOf(\Psr\Http\Message\ServerRequestInterface::class, $psr);
+    }
+
+    public function test_legacy_request_from_psr(): void
+    {
+        $psr = new ServerRequest('PUT', 'http://example.com/api', ['X-Internal' => 'true'], 'body');
+        $psr = $psr
+            ->withQueryParams(['id' => 5])
+            ->withParsedBody(['name' => 'test']);
+
+        $req = \SDF\Request::fromPsr($psr);
+        $this->assertInstanceOf(\SDF\Request::class, $req);
+        $this->assertSame('PUT', $_SERVER['REQUEST_METHOD']);
+        $this->assertSame(['id' => 5], $_GET);
+        $this->assertSame(['name' => 'test'], $_POST);
+    }
+
+    public function test_legacy_response_to_psr(): void
+    {
+        $res = new \SDF\Response();
+        $res->setHttpCode(201);
+        $res->setContent(json_encode(['ok' => true]));
+        $res->setHeader('Content-Type', 'application/json');
+
+        $psr = $res->toPsr();
+        $this->assertInstanceOf(\Psr\Http\Message\ResponseInterface::class, $psr);
+        $this->assertSame(201, $psr->getStatusCode());
+        $this->assertSame('application/json', $psr->getHeaderLine('Content-Type'));
+        $this->assertSame(json_encode(['ok' => true]), (string) $psr->getBody());
+    }
+
+    public function test_legacy_response_from_psr(): void
+    {
+        $psr = new Response(404, ['X-Error' => 'not_found'], new Stream('oops'));
+        $res = \SDF\Response::fromPsr($psr);
+        $this->assertSame(404, $res->statusCode());
+        $this->assertSame('oops', $res->getContent());
+    }
+}

--- a/tests/ModelRelationshipTest.php
+++ b/tests/ModelRelationshipTest.php
@@ -1,0 +1,208 @@
+<?php
+
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+use SDF\Spark;
+use SDF\Spark\Model;
+use SDF\Spark\Paginator;
+
+class UserMdl extends Model
+{
+    protected static string $table = 'users_mdl';
+}
+
+class ProfileMdl extends Model
+{
+    protected static string $table = 'profiles_mdl';
+}
+
+class PostMdl extends Model
+{
+    protected static string $table = 'posts_mdl';
+}
+
+class RoleMdl extends Model
+{
+    protected static string $table = 'roles_mdl';
+}
+
+class ModelRelationshipTest extends TestCase
+{
+    private static bool $migrated = false;
+
+    public static function setUpBeforeClass(): void
+    {
+        Spark::connect('sqlite::memory:');
+
+        if (!self::$migrated) {
+            Spark::pdo()->exec("
+                CREATE TABLE users_mdl (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name TEXT NOT NULL
+                )
+            ");
+            Spark::pdo()->exec("
+                CREATE TABLE profiles_mdl (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    user_mdl_id INTEGER NOT NULL,
+                    bio TEXT NOT NULL
+                )
+            ");
+            Spark::pdo()->exec("
+                CREATE TABLE posts_mdl (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    user_mdl_id INTEGER NOT NULL,
+                    title TEXT NOT NULL
+                )
+            ");
+            Spark::pdo()->exec("
+                CREATE TABLE roles_mdl (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name TEXT NOT NULL
+                )
+            ");
+            Spark::pdo()->exec("
+                CREATE TABLE role_mdl_user_mdl (
+                    role_mdl_id INTEGER NOT NULL,
+                    user_mdl_id INTEGER NOT NULL
+                )
+            ");
+
+            Spark::pdo()->exec("INSERT INTO users_mdl (name) VALUES ('Alice')");
+            Spark::pdo()->exec("INSERT INTO users_mdl (name) VALUES ('Bob')");
+            Spark::pdo()->exec("INSERT INTO profiles_mdl (user_mdl_id, bio) VALUES (1, 'Alice bio')");
+            Spark::pdo()->exec("INSERT INTO posts_mdl (user_mdl_id, title) VALUES (1, 'Post 1')");
+            Spark::pdo()->exec("INSERT INTO posts_mdl (user_mdl_id, title) VALUES (1, 'Post 2')");
+            Spark::pdo()->exec("INSERT INTO posts_mdl (user_mdl_id, title) VALUES (2, 'Post 3')");
+            Spark::pdo()->exec("INSERT INTO roles_mdl (name) VALUES ('Admin')");
+            Spark::pdo()->exec("INSERT INTO roles_mdl (name) VALUES ('Editor')");
+            Spark::pdo()->exec("INSERT INTO role_mdl_user_mdl (role_mdl_id, user_mdl_id) VALUES (1, 1)");
+            Spark::pdo()->exec("INSERT INTO role_mdl_user_mdl (role_mdl_id, user_mdl_id) VALUES (2, 1)");
+
+            self::$migrated = true;
+        }
+    }
+
+    protected function setUp(): void
+    {
+        Spark::connect('sqlite::memory:');
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        Spark::disconnect();
+    }
+
+    public function test_has_one_returns_related(): void
+    {
+        $user = UserMdl::find(1);
+        $this->assertNotNull($user);
+
+        $profile = $user->hasOne(ProfileMdl::class);
+        $this->assertNotNull($profile);
+        $this->assertSame('Alice bio', $profile->bio);
+    }
+
+    public function test_has_one_returns_null_when_no_related(): void
+    {
+        $user = UserMdl::find(2);
+        $this->assertNotNull($user);
+
+        $profile = $user->hasOne(ProfileMdl::class);
+        $this->assertNull($profile);
+    }
+
+    public function test_has_many_returns_collection(): void
+    {
+        $user = UserMdl::find(1);
+        $this->assertNotNull($user);
+
+        $posts = $user->hasMany(PostMdl::class);
+        $this->assertCount(2, $posts);
+    }
+
+    public function test_has_many_returns_empty_when_none(): void
+    {
+        $user = new UserMdl(['id' => 999], false);
+        $user->fill(['id' => 999]);
+
+        $posts = $user->hasMany(PostMdl::class);
+        $this->assertEmpty($posts);
+    }
+
+    public function test_belongs_to_returns_parent(): void
+    {
+        $post = PostMdl::find(1);
+        $this->assertNotNull($post);
+
+        $user = $post->belongsTo(UserMdl::class);
+        $this->assertNotNull($user);
+        $this->assertSame('Alice', $user->name);
+    }
+
+    public function test_belongs_to_returns_null_when_no_parent(): void
+    {
+        $post = new PostMdl(['user_id' => 999], false);
+        $post->fill(['user_id' => 999]);
+
+        try {
+            $user = $post->belongsTo(UserMdl::class);
+            $this->assertNull($user);
+        } catch (\PDOException $e) {
+            throw new \Exception(
+                $e->getMessage() . "\nSQL: " . ($e->getPrevious()?->getMessage() ?? 'N/A'),
+                $e->getCode(),
+                $e
+            );
+        }
+    }
+
+    public function test_belongs_to_many_returns_related(): void
+    {
+        $user = UserMdl::find(1);
+        $this->assertNotNull($user);
+
+        $roles = $user->belongsToMany(RoleMdl::class);
+        $this->assertCount(2, $roles);
+        $names = array_map(fn ($r) => $r->name, $roles);
+        $this->assertContains('Admin', $names);
+        $this->assertContains('Editor', $names);
+    }
+
+    public function test_belongs_to_many_returns_empty_when_no_relation(): void
+    {
+        $user = UserMdl::find(2);
+        $this->assertNotNull($user);
+
+        $roles = $user->belongsToMany(RoleMdl::class);
+        $this->assertEmpty($roles);
+    }
+
+    public function test_paginate_returns_paginator(): void
+    {
+        $result = UserMdl::query()->paginate(1, 1);
+        $this->assertInstanceOf(Paginator::class, $result);
+        $this->assertCount(1, $result->items());
+        $this->assertSame(2, $result->total());
+        $this->assertSame(1, $result->perPage());
+        $this->assertSame(1, $result->currentPage());
+        $this->assertTrue($result->hasMore());
+    }
+
+    public function test_paginate_second_page(): void
+    {
+        $result = UserMdl::query()->paginate(1, 2);
+        $this->assertCount(1, $result->items());
+        $this->assertSame(2, $result->currentPage());
+        $this->assertFalse($result->hasMore());
+    }
+
+    public function test_paginate_with_wheres(): void
+    {
+        $result = UserMdl::query()->where('name', 'Alice')->paginate(15, 1);
+        $this->assertCount(1, $result->items());
+        $this->assertSame('Alice', $result->items()[0]->name);
+        $this->assertSame(1, $result->total());
+    }
+}

--- a/tests/PaginatorTest.php
+++ b/tests/PaginatorTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+use SDF\Spark\Paginator;
+
+class PaginatorTest extends TestCase
+{
+    public function test_returns_items(): void
+    {
+        $p = new Paginator(['a', 'b'], 10, 2, 1);
+        $this->assertSame(['a', 'b'], $p->items());
+    }
+
+    public function test_total(): void
+    {
+        $p = new Paginator([], 42, 15, 1);
+        $this->assertSame(42, $p->total());
+    }
+
+    public function test_per_page(): void
+    {
+        $p = new Paginator([], 42, 15, 1);
+        $this->assertSame(15, $p->perPage());
+    }
+
+    public function test_current_page(): void
+    {
+        $p = new Paginator([], 42, 15, 3);
+        $this->assertSame(3, $p->currentPage());
+    }
+
+    public function test_last_page_calculation(): void
+    {
+        $p = new Paginator([], 42, 15, 1);
+        $this->assertSame(3, $p->lastPage());
+
+        $p2 = new Paginator([], 45, 15, 1);
+        $this->assertSame(3, $p2->lastPage());
+
+        $p3 = new Paginator([], 46, 15, 1);
+        $this->assertSame(4, $p3->lastPage());
+    }
+
+    public function test_has_more_when_not_on_last_page(): void
+    {
+        $p = new Paginator([], 42, 15, 1);
+        $this->assertTrue($p->hasMore());
+
+        $p2 = new Paginator([], 42, 15, 3);
+        $this->assertFalse($p2->hasMore());
+    }
+
+    public function test_has_pages_when_multiple_pages(): void
+    {
+        $p = new Paginator([], 100, 10, 1);
+        $this->assertTrue($p->hasPages());
+    }
+
+    public function test_no_pages_when_single_page(): void
+    {
+        $p = new Paginator([], 5, 10, 1);
+        $this->assertFalse($p->hasPages());
+    }
+
+    public function test_on_first_page(): void
+    {
+        $p = new Paginator([], 42, 15, 1);
+        $this->assertTrue($p->onFirstPage());
+
+        $p2 = new Paginator([], 42, 15, 2);
+        $this->assertFalse($p2->onFirstPage());
+    }
+
+    public function test_is_empty(): void
+    {
+        $p = new Paginator([], 0, 15, 1);
+        $this->assertTrue($p->isEmpty());
+        $this->assertFalse($p->isNotEmpty());
+    }
+
+    public function test_is_not_empty(): void
+    {
+        $p = new Paginator(['x'], 1, 15, 1);
+        $this->assertFalse($p->isEmpty());
+        $this->assertTrue($p->isNotEmpty());
+    }
+
+    public function test_count(): void
+    {
+        $p = new Paginator(['a', 'b', 'c'], 10, 3, 1);
+        $this->assertSame(3, $p->count());
+    }
+
+    public function test_to_array(): void
+    {
+        $p = new Paginator(['a', 'b'], 20, 10, 2);
+        $result = $p->toArray();
+        $this->assertSame(['a', 'b'], $result['items']);
+        $this->assertSame(20, $result['pagination']['total']);
+        $this->assertSame(10, $result['pagination']['per_page']);
+        $this->assertSame(2, $result['pagination']['current_page']);
+        $this->assertSame(2, $result['pagination']['last_page']);
+        $this->assertFalse($result['pagination']['has_more']);
+    }
+
+    public function test_get_iterator(): void
+    {
+        $items = ['a', 'b', 'c'];
+        $p = new Paginator($items, 3, 10, 1);
+        $iter = $p->getIterator();
+        $this->assertInstanceOf(\ArrayIterator::class, $iter);
+        $this->assertCount(3, $iter);
+    }
+
+    public function test_handles_zero_total(): void
+    {
+        $p = new Paginator([], 0, 15, 1);
+        $this->assertSame(0, $p->lastPage());
+        $this->assertFalse($p->hasMore());
+        $this->assertFalse($p->hasPages());
+        $this->assertTrue($p->isEmpty());
+    }
+}

--- a/tests/RateLimitTest.php
+++ b/tests/RateLimitTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * SDF Rate-Limit Middleware tests.
+ *
+ * @package     Tests
+ * @file        RateLimitTest.php
+ * @author      devsimsek
+ * @copyright   Copyright (c) 2022-2026, smskSoft, devsimsek
+ * @license     https://opensource.org/licenses/MIT MIT License
+ */
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+use SDF\Cache\Cache;
+use SDF\Cache\FileDriver;
+use SDF\Middleware\RateLimitMiddleware;
+use ReflectionClass;
+
+class RateLimitTest extends TestCase
+{
+    private RateLimitMiddleware $middleware;
+
+    protected function setUp(): void
+    {
+        Cache::setDriver(new FileDriver(['path' => sys_get_temp_dir() . '/sdf_cache_test/', 'prefix' => 'ratelimit_test_']));
+        Cache::clear();
+        $this->middleware = new RateLimitMiddleware(maxAttempts: 5, decaySeconds: 60);
+    }
+
+    protected function tearDown(): void
+    {
+        Cache::clear();
+    }
+
+    public function test_getAttempts_returns_zero_initially(): void
+    {
+        $ref = new ReflectionClass($this->middleware);
+        $method = $ref->getMethod('getAttempts');
+
+        $this->assertSame(0, $method->invoke($this->middleware, 'test:127.0.0.1|/'));
+    }
+
+    public function test_hit_increments_count(): void
+    {
+        $ref = new ReflectionClass($this->middleware);
+        $hit = $ref->getMethod('hit');
+        $get = $ref->getMethod('getAttempts');
+
+        $key = 'test:127.0.0.1|/test';
+        $hit->invoke($this->middleware, $key);
+        $this->assertSame(1, $get->invoke($this->middleware, $key));
+    }
+
+    public function test_multiple_hits_accumulate(): void
+    {
+        $ref = new ReflectionClass($this->middleware);
+        $hit = $ref->getMethod('hit');
+        $get = $ref->getMethod('getAttempts');
+
+        $key = 'test:127.0.0.1|/accum';
+        for ($i = 0; $i < 3; $i++) {
+            $hit->invoke($this->middleware, $key);
+        }
+        $this->assertSame(3, $get->invoke($this->middleware, $key));
+    }
+
+    public function test_retryAfter_returns_decay_when_no_data(): void
+    {
+        $ref = new ReflectionClass($this->middleware);
+        $method = $ref->getMethod('retryAfter');
+
+        $this->assertSame(60, $method->invoke($this->middleware, 'nonexistent'));
+    }
+
+    public function test_resolveKey_returns_sha1(): void
+    {
+        $ref = new ReflectionClass($this->middleware);
+        $method = $ref->getMethod('resolveKey');
+
+        $key = $method->invoke($this->middleware, $this->createMock(\SDF\Request::class));
+        $this->assertStringStartsWith('ratelimit:', $key);
+    }
+}

--- a/tests/SessionTest.php
+++ b/tests/SessionTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use SDF\Session;
+
+class SessionTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
+        $_SESSION = [];
+        $this->resetSessionInstance();
+    }
+
+    protected function tearDown(): void
+    {
+        $_SESSION = [];
+        $this->resetSessionInstance();
+    }
+
+    public function test_session_set_and_get(): void
+    {
+        $session = new Session();
+        $session->set('name', 'Alice');
+        $this->assertSame('Alice', $session->get('name'));
+    }
+
+    public function test_session_get_returns_default_on_miss(): void
+    {
+        $session = new Session();
+        $this->assertNull($session->get('missing'));
+        $this->assertSame('fallback', $session->get('missing', 'fallback'));
+    }
+
+    public function test_session_has(): void
+    {
+        $session = new Session();
+        $this->assertFalse($session->has('key'));
+        $session->set('key', 'value');
+        $this->assertTrue($session->has('key'));
+    }
+
+    public function test_session_remove(): void
+    {
+        $session = new Session();
+        $session->set('key', 'value');
+        $session->remove('key');
+        $this->assertFalse($session->has('key'));
+    }
+
+    public function test_session_clear(): void
+    {
+        $session = new Session();
+        $session->set('a', 1);
+        $session->set('b', 2);
+        $session->clear();
+        $this->assertSame([], $_SESSION);
+    }
+
+    public function test_session_set_is_fluent(): void
+    {
+        $session = new Session();
+        $result = $session->set('key', 'value');
+        $this->assertSame($session, $result);
+    }
+
+    public function test_session_id(): void
+    {
+        $session = new Session();
+        $id = $session->id();
+        $this->assertIsString($id);
+        $this->assertNotEmpty($id);
+    }
+
+    public function test_session_regenerate(): void
+    {
+        $session = new Session();
+        $oldId = $session->id();
+        $session->regenerate();
+        $this->assertNotSame($oldId, $session->id());
+    }
+
+    public function test_session_destroy_clears_data(): void
+    {
+        $session = new Session();
+        $session->set('key', 'value');
+        $session->destroy();
+        // After destroy, session is empty; start a new one to verify
+        session_start();
+        $this->assertArrayNotHasKey('key', $_SESSION);
+    }
+
+    public function test_session_getInstance_returns_singleton(): void
+    {
+        $a = Session::getInstance();
+        $b = Session::getInstance();
+        $this->assertSame($a, $b);
+    }
+
+    public function test_session_allows_null_false_and_zero_values(): void
+    {
+        $session = new Session();
+        $session->set('null', null);
+        $session->set('false', false);
+        $session->set('zero', 0);
+
+        $this->assertTrue($session->has('null'));
+        $this->assertNull($session->get('null'));
+        $this->assertFalse($session->get('false'));
+        $this->assertSame(0, $session->get('zero'));
+    }
+
+    private function resetSessionInstance(): void
+    {
+        $ref = new ReflectionClass(Session::class);
+        $prop = $ref->getProperty('instance');
+        $prop->setValue(null, null);
+    }
+}

--- a/tests/SwaggerTest.php
+++ b/tests/SwaggerTest.php
@@ -1,0 +1,144 @@
+<?php
+
+/**
+ * SDF Swagger/OpenAPI integration tests.
+ *
+ * @package     Tests
+ * @file        SwaggerTest.php
+ * @author      devsimsek
+ * @copyright   Copyright (c) 2022-2026, smskSoft, devsimsek
+ * @license     https://opensource.org/licenses/MIT MIT License
+ */
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+use SDF\Swagger\SwaggerGenerator;
+
+/**
+ * Tests for the SDF Swagger/OpenAPI integration.
+ *
+ * @covers \SDF\Swagger\SwaggerGenerator
+ * @covers \SDF\Swagger\SwaggerController
+ */
+class SwaggerTest extends TestCase
+{
+    /**
+     * Generator output is valid JSON with openapi, info, servers, paths keys.
+     */
+    public function test_generator_returns_valid_json(): void
+    {
+        $generator = new SwaggerGenerator(
+            title: 'Test API',
+            apiVersion: '2.0.0',
+            serverUrl: 'http://test.dev',
+        );
+
+        $json = $generator->generate();
+
+        $this->assertJson($json);
+
+        $data = json_decode($json, true);
+        $this->assertArrayHasKey('openapi', $data);
+        $this->assertArrayHasKey('info', $data);
+        $this->assertArrayHasKey('servers', $data);
+        $this->assertArrayHasKey('paths', $data);
+    }
+
+    /**
+     * Custom title and version appear in the generated spec.
+     */
+    public function test_generator_sets_title_and_version(): void
+    {
+        $generator = new SwaggerGenerator(
+            title: 'My Custom API',
+            apiVersion: '3.1.0',
+            serverUrl: 'http://example.com',
+        );
+
+        $data = $generator->generateArray();
+
+        $this->assertSame('My Custom API', $data['info']['title']);
+        $this->assertSame('3.1.0', $data['info']['version']);
+    }
+
+    /**
+     * generateArray() returns an associative array with openapi version.
+     */
+    public function test_generator_array_output(): void
+    {
+        $generator = new SwaggerGenerator();
+        $array = $generator->generateArray();
+
+        $this->assertIsArray($array);
+        $this->assertSame('3.0.0', $array['openapi']);
+    }
+
+    /**
+     * Server URL passed to the constructor appears in the output.
+     */
+    public function test_generator_adds_server_url(): void
+    {
+        $generator = new SwaggerGenerator(
+            serverUrl: 'https://api.example.com/v2',
+        );
+
+        $data = $generator->generateArray();
+
+        $this->assertArrayHasKey('servers', $data);
+        $this->assertSame('https://api.example.com/v2', $data['servers'][0]['url']);
+    }
+
+    /**
+     * Default title/version are used when no arguments are given.
+     */
+    public function test_generator_uses_defaults_when_not_specified(): void
+    {
+        $generator = new SwaggerGenerator();
+        $data = $generator->generateArray();
+
+        $this->assertSame('SDF API', $data['info']['title']);
+        $this->assertSame('1.0.0', $data['info']['version']);
+    }
+
+    /**
+     * Paths key is always an array (empty by default).
+     */
+    public function test_generator_paths_is_array(): void
+    {
+        $generator = new SwaggerGenerator();
+        $data = $generator->generateArray();
+
+        $this->assertIsArray($data['paths']);
+    }
+
+    /**
+     * CLI script contains the swagger:generate command handler.
+     */
+    public function test_cli_has_swagger_command(): void
+    {
+        $source = file_get_contents(SDF_DIR . '../sdf/cli');
+        $this->assertStringContainsString('case "swagger":', $source);
+        $this->assertStringContainsString('private function handleSwagger', $source);
+        $this->assertStringContainsString('case "generate":', $source);
+    }
+
+    /**
+     * Generated spec contains all required OpenAPI 3.x fields.
+     */
+    public function test_generated_json_is_valid_openapi(): void
+    {
+        $generator = new SwaggerGenerator();
+        $data = $generator->generateArray();
+
+        // OpenAPI 3.x required fields
+        $this->assertArrayHasKey('openapi', $data);
+        $this->assertMatchesRegularExpression('/^3\.\d+\.\d+$/', $data['openapi']);
+
+        // Info object must have title + version
+        $this->assertArrayHasKey('title', $data['info']);
+        $this->assertArrayHasKey('version', $data['info']);
+    }
+}

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -1,0 +1,336 @@
+<?php
+
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+use SDF\Validation\Validator;
+
+class ValidationTest extends TestCase
+{
+    public function test_required_passes(): void
+    {
+        $v = Validator::make(['name' => 'John'], ['name' => 'required']);
+        $this->assertTrue($v->validate());
+    }
+
+    public function test_required_fails(): void
+    {
+        $v = Validator::make(['name' => ''], ['name' => 'required']);
+        $this->assertFalse($v->validate());
+        $this->assertArrayHasKey('name', $v->errors());
+    }
+
+    public function test_required_with_null_value(): void
+    {
+        $v = Validator::make(['name' => null], ['name' => 'required']);
+        $this->assertFalse($v->validate());
+    }
+
+    public function test_required_with_missing_field(): void
+    {
+        $v = Validator::make([], ['name' => 'required']);
+        $this->assertFalse($v->validate());
+    }
+
+    public function test_email_passes(): void
+    {
+        $v = Validator::make(['email' => 'user@example.com'], ['email' => 'email']);
+        $this->assertTrue($v->validate());
+    }
+
+    public function test_email_fails(): void
+    {
+        $v = Validator::make(['email' => 'not-an-email'], ['email' => 'email']);
+        $this->assertFalse($v->validate());
+    }
+
+    public function test_min_string_passes(): void
+    {
+        $v = Validator::make(['name' => 'Hello'], ['name' => 'min:3']);
+        $this->assertTrue($v->validate());
+    }
+
+    public function test_min_string_fails(): void
+    {
+        $v = Validator::make(['name' => 'Hi'], ['name' => 'min:3']);
+        $this->assertFalse($v->validate());
+    }
+
+    public function test_max_string_passes(): void
+    {
+        $v = Validator::make(['name' => 'Hi'], ['name' => 'max:5']);
+        $this->assertTrue($v->validate());
+    }
+
+    public function test_max_string_fails(): void
+    {
+        $v = Validator::make(['name' => 'TooLongName'], ['name' => 'max:5']);
+        $this->assertFalse($v->validate());
+    }
+
+    public function test_numeric_passes(): void
+    {
+        $v = Validator::make(['age' => '25'], ['age' => 'numeric']);
+        $this->assertTrue($v->validate());
+    }
+
+    public function test_numeric_fails(): void
+    {
+        $v = Validator::make(['age' => 'abc'], ['age' => 'numeric']);
+        $this->assertFalse($v->validate());
+    }
+
+    public function test_integer_passes(): void
+    {
+        $v = Validator::make(['count' => '42'], ['count' => 'integer']);
+        $this->assertTrue($v->validate());
+    }
+
+    public function test_integer_fails(): void
+    {
+        $v = Validator::make(['count' => '12.5'], ['count' => 'integer']);
+        $this->assertFalse($v->validate());
+    }
+
+    public function test_string_passes(): void
+    {
+        $v = Validator::make(['text' => 'hello'], ['text' => 'string']);
+        $this->assertTrue($v->validate());
+    }
+
+    public function test_string_fails_for_array(): void
+    {
+        $v = Validator::make(['text' => [1, 2]], ['text' => 'string']);
+        $this->assertFalse($v->validate());
+    }
+
+    public function test_boolean_passes(): void
+    {
+        $v = Validator::make(['active' => true], ['active' => 'boolean']);
+        $this->assertTrue($v->validate());
+    }
+
+    public function test_boolean_accepts_string_one(): void
+    {
+        $v = Validator::make(['active' => '1'], ['active' => 'boolean']);
+        $this->assertTrue($v->validate());
+    }
+
+    public function test_array_passes(): void
+    {
+        $v = Validator::make(['items' => [1, 2]], ['items' => 'array']);
+        $this->assertTrue($v->validate());
+    }
+
+    public function test_array_fails(): void
+    {
+        $v = Validator::make(['items' => 'string'], ['items' => 'array']);
+        $this->assertFalse($v->validate());
+    }
+
+    public function test_alpha_passes(): void
+    {
+        $v = Validator::make(['name' => 'John'], ['name' => 'alpha']);
+        $this->assertTrue($v->validate());
+    }
+
+    public function test_alpha_fails_with_numbers(): void
+    {
+        $v = Validator::make(['name' => 'John123'], ['name' => 'alpha']);
+        $this->assertFalse($v->validate());
+    }
+
+    public function test_alpha_num_passes(): void
+    {
+        $v = Validator::make(['name' => 'John123'], ['name' => 'alpha_num']);
+        $this->assertTrue($v->validate());
+    }
+
+    public function test_url_passes(): void
+    {
+        $v = Validator::make(['site' => 'https://example.com'], ['site' => 'url']);
+        $this->assertTrue($v->validate());
+    }
+
+    public function test_url_fails(): void
+    {
+        $v = Validator::make(['site' => 'not-a-url'], ['site' => 'url']);
+        $this->assertFalse($v->validate());
+    }
+
+    public function test_in_passes(): void
+    {
+        $v = Validator::make(['role' => 'admin'], ['role' => 'in:admin,user,guest']);
+        $this->assertTrue($v->validate());
+    }
+
+    public function test_in_fails(): void
+    {
+        $v = Validator::make(['role' => 'superadmin'], ['role' => 'in:admin,user,guest']);
+        $this->assertFalse($v->validate());
+    }
+
+    public function test_confirmed_passes(): void
+    {
+        $v = Validator::make([
+            'password' => 'secret',
+            'password_confirmation' => 'secret',
+        ], ['password' => 'confirmed']);
+        $this->assertTrue($v->validate());
+    }
+
+    public function test_confirmed_fails(): void
+    {
+        $v = Validator::make([
+            'password' => 'secret',
+            'password_confirmation' => 'different',
+        ], ['password' => 'confirmed']);
+        $this->assertFalse($v->validate());
+    }
+
+    public function test_same_passes(): void
+    {
+        $v = Validator::make([
+            'a' => 'value',
+            'b' => 'value',
+        ], ['a' => 'same:b']);
+        $this->assertTrue($v->validate());
+    }
+
+    public function test_different_passes(): void
+    {
+        $v = Validator::make([
+            'a' => 'value1',
+            'b' => 'value2',
+        ], ['a' => 'different:b']);
+        $this->assertTrue($v->validate());
+    }
+
+    public function test_regex_passes(): void
+    {
+        $v = Validator::make(['phone' => '555-1234'], ['phone' => 'regex:/^\d{3}-\d{4}$/']);
+        $this->assertTrue($v->validate());
+    }
+
+    public function test_regex_fails(): void
+    {
+        $v = Validator::make(['phone' => 'abc'], ['phone' => 'regex:/^\d{3}-\d{4}$/']);
+        $this->assertFalse($v->validate());
+    }
+
+    public function test_between_string_passes(): void
+    {
+        $v = Validator::make(['name' => 'Hello'], ['name' => 'between:3,10']);
+        $this->assertTrue($v->validate());
+    }
+
+    public function test_between_string_fails_below(): void
+    {
+        $v = Validator::make(['name' => 'Hi'], ['name' => 'between:3,10']);
+        $this->assertFalse($v->validate());
+    }
+
+    public function test_between_string_fails_above(): void
+    {
+        $v = Validator::make(['name' => 'ThisIsWayTooLong'], ['name' => 'between:3,10']);
+        $this->assertFalse($v->validate());
+    }
+
+    public function test_nullable_allows_missing(): void
+    {
+        $v = Validator::make([], ['email' => 'nullable|email']);
+        $this->assertTrue($v->validate());
+    }
+
+    public function test_nullable_allows_null(): void
+    {
+        $v = Validator::make(['email' => null], ['email' => 'nullable|email']);
+        $this->assertTrue($v->validate());
+    }
+
+    public function test_nullable_still_validates_non_null(): void
+    {
+        $v = Validator::make(['email' => 'not-email'], ['email' => 'nullable|email']);
+        $this->assertFalse($v->validate());
+    }
+
+    public function test_multiple_rules_on_one_field(): void
+    {
+        $v = Validator::make(['name' => ''], ['name' => 'required|string|min:3']);
+        $this->assertFalse($v->validate());
+    }
+
+    public function test_passes_on_valid_data(): void
+    {
+        $v = Validator::make(['name' => 'John'], ['name' => 'required|string|min:2|max:50']);
+        $this->assertTrue($v->validate());
+        $this->assertTrue($v->passes());
+        $this->assertFalse($v->fails());
+    }
+
+    public function test_errors_returns_array(): void
+    {
+        $v = Validator::make(['name' => ''], ['name' => 'required']);
+        $v->validate();
+        $errors = $v->errors();
+        $this->assertIsArray($errors);
+        $this->assertCount(1, $errors['name']);
+    }
+
+    public function test_custom_message(): void
+    {
+        $v = Validator::make(['name' => ''], ['name' => 'required']);
+        $v->setMessages(['name.required' => 'Name is missing!']);
+        $v->validate();
+        $this->assertSame('Name is missing!', $v->errors()['name'][0]);
+    }
+
+    public function test_field_alias_in_message(): void
+    {
+        $v = Validator::make(['user_email' => ''], ['user_email' => 'required|email']);
+        $v->setAliases(['user_email' => 'email address']);
+        $v->validate();
+        $msg = $v->errors()['user_email'][0];
+        $this->assertStringContainsString('email address', $msg);
+    }
+
+    public function test_custom_rule_added(): void
+    {
+        $v = Validator::make(['value' => 'hello'], ['value' => 'custom_rule']);
+        $v->addRule('custom_rule', fn ($value) => $value === 'hello');
+        $this->assertTrue($v->validate());
+    }
+
+    public function test_custom_rule_fails(): void
+    {
+        $v = Validator::make(['value' => 'world'], ['value' => 'custom_rule']);
+        $v->addRule('custom_rule', fn ($value) => $value === 'hello');
+        $this->assertFalse($v->validate());
+    }
+
+    public function test_make_static_helper(): void
+    {
+        $v = Validator::make(['x' => 'hello'], ['x' => 'required|string']);
+        $this->assertInstanceOf(Validator::class, $v);
+        $this->assertTrue($v->validate());
+    }
+
+    public function test_min_on_numeric(): void
+    {
+        $v = Validator::make(['age' => 18], ['age' => 'numeric|min:18']);
+        $this->assertTrue($v->validate());
+    }
+
+    public function test_max_on_numeric(): void
+    {
+        $v = Validator::make(['age' => 100], ['age' => 'numeric|max:99']);
+        $this->assertFalse($v->validate());
+    }
+
+    public function test_errors_empty_when_valid(): void
+    {
+        $v = Validator::make(['name' => 'John'], ['name' => 'required']);
+        $v->validate();
+        $this->assertEmpty($v->errors());
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -62,6 +62,8 @@ require_once SDF_DIR . 'core/Encryption/Encrypter.php';
 require_once SDF_DIR . 'core/Middleware/CsrfMiddleware.php';
 require_once SDF_DIR . 'core/Middleware/CorsMiddleware.php';
 require_once SDF_DIR . 'core/Middleware/RateLimitMiddleware.php';
+require_once SDF_DIR . 'core/Validation/Validator.php';
+require_once SDF_DIR . 'core/Spark/Paginator.php';
 
 // Test helpers
 require_once __DIR__ . '/TestMiddlewares.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -43,6 +43,8 @@ require_once SDF_DIR . 'core/Cache/Cache.php';
 require_once SDF_DIR . 'core/Cache/FileDriver.php';
 require_once SDF_DIR . 'core/Cache/RedisDriver.php';
 require_once SDF_DIR . 'core/Cache/MemcachedDriver.php';
+require_once SDF_DIR . 'core/Session.php';
+require_once SDF_DIR . 'core/Flash.php';
 
 // Test helpers
 require_once __DIR__ . '/TestMiddlewares.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -51,6 +51,11 @@ require_once SDF_DIR . 'core/Auth/SessionGuard.php';
 require_once SDF_DIR . 'core/Auth/JwtGuard.php';
 require_once SDF_DIR . 'core/Auth/Auth.php';
 require_once SDF_DIR . 'core/Auth/AuthMiddleware.php';
+require_once SDF_DIR . 'core/Http/Stream.php';
+require_once SDF_DIR . 'core/Http/Uri.php';
+require_once SDF_DIR . 'core/Http/UploadedFile.php';
+require_once SDF_DIR . 'core/Http/Response.php';
+require_once SDF_DIR . 'core/Http/ServerRequest.php';
 
 // Test helpers
 require_once __DIR__ . '/TestMiddlewares.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -45,6 +45,12 @@ require_once SDF_DIR . 'core/Cache/RedisDriver.php';
 require_once SDF_DIR . 'core/Cache/MemcachedDriver.php';
 require_once SDF_DIR . 'core/Session.php';
 require_once SDF_DIR . 'core/Flash.php';
+require_once SDF_DIR . 'core/Auth/Guard.php';
+require_once SDF_DIR . 'core/Auth/UserProvider.php';
+require_once SDF_DIR . 'core/Auth/SessionGuard.php';
+require_once SDF_DIR . 'core/Auth/JwtGuard.php';
+require_once SDF_DIR . 'core/Auth/Auth.php';
+require_once SDF_DIR . 'core/Auth/AuthMiddleware.php';
 
 // Test helpers
 require_once __DIR__ . '/TestMiddlewares.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -56,6 +56,12 @@ require_once SDF_DIR . 'core/Http/Uri.php';
 require_once SDF_DIR . 'core/Http/UploadedFile.php';
 require_once SDF_DIR . 'core/Http/Response.php';
 require_once SDF_DIR . 'core/Http/ServerRequest.php';
+require_once SDF_DIR . 'core/Env.php';
+require_once SDF_DIR . 'core/helpers.php';
+require_once SDF_DIR . 'core/Encryption/Encrypter.php';
+require_once SDF_DIR . 'core/Middleware/CsrfMiddleware.php';
+require_once SDF_DIR . 'core/Middleware/CorsMiddleware.php';
+require_once SDF_DIR . 'core/Middleware/RateLimitMiddleware.php';
 
 // Test helpers
 require_once __DIR__ . '/TestMiddlewares.php';

--- a/wiki/agentic_workflow/introduction.md
+++ b/wiki/agentic_workflow/introduction.md
@@ -1,0 +1,16 @@
+# Agentic Workflow — Project SDF
+
+This directory contains agentic development workflows for Project SDF. Agents use the [project-sdf skill](skills/project-sdf.md) to understand codebase conventions, commands, architecture, and testing quirks before making changes.
+
+## Workflows
+
+| Guide | Description |
+|-------|-------------|
+| [Setup Guide](tutorials/setup.md) | Configure your agent/IDE for SDF development |
+| [Skill Reference](skills/project-sdf.md) | Full codebase skill for agents |
+
+## Goals
+
+- Enable AI agents to work autonomously on SDF framework code
+- Maintain consistent code style, architecture, and testing standards
+- Reduce context needed per task by centralising conventions in the skill

--- a/wiki/agentic_workflow/skills/project-sdf.md
+++ b/wiki/agentic_workflow/skills/project-sdf.md
@@ -1,0 +1,113 @@
+# Project SDF — Agent Skill
+
+## Quick start
+```bash
+composer install
+vendor/bin/phpunit --testdox
+vendor/bin/phpunit --filter=CoreSurface --testdox
+composer analyze
+composer cs:fix
+composer cs:check
+```
+
+## CLI
+```bash
+php sdf/cli serve -p 8000              # dev server (auto-detect frankenphp or PHP built-in)
+php sdf/cli serve -p 8000 --live       # with live-reload watcher
+php sdf/cli g controller Home          # generate component
+php sdf/cli g test UserController --type=controller --namespace=App\\Controllers\\User
+php sdf/cli db migrate                 # run pending migrations
+php sdf/cli cache clear                # clear framework caches
+php sdf/cli format --dry-run -v        # run cs-fixer via CLI
+```
+
+## Architecture
+- **Entry**: `index.php` defines constants (`SDF`, `USE_FUSE`, `SDF_ENV`, etc.) then requires `sdf/__init.php`.
+- **PSR-4**: `SDF\` → `sdf/core/`, `Tests\` → `tests/`.
+- **CoreUtilities trait** on `SDF\Core` holds shared static state (`$classes`, `$config`).
+- **Config**: `app/config/*.php` or `app/config/*.json`; files declare `$config['key'] = [...]`. Cached to `sys_get_temp_dir()/sdf_config.cache`.
+- **No DI container** — classes use `Core::coreLoadClass()` singleton-style loading.
+- **Router cache**: `sys_get_temp_dir()/sdf_routes.cache`.
+- **Cache facade**: `SDF\Cache\Cache` — PSR-16 proxy. Driver (`file`/`redis`/`memcached`) set in `app/config/cache.php`.
+- **Fuse view engine**: compiles templates via Cache facade; raw files also written to `sys_get_temp_dir()/fuse_cache/` for `require`.
+
+## Testing quirks
+- PHPUnit 10, bootstrap `tests/bootstrap.php` defines framework constants + requires all core files.
+- Tests use `ReflectionClass` extensively to access private static properties (no public getters/setters). See `CoreSurfaceTest.php`, `QueryBuilderTest.php` for patterns.
+- **Must reset static state** in `setUp`/`tearDown` — `Core::$config`, `Router::$routes/$middlewares/$config` are shared.
+- CLI generator tests (`CLIGeneratorTest.php`) run in temp dirs.
+- SQLite in-memory connections for integration-style tests (`Spark::connect('sqlite::memory:')`).
+- Use `$this->getProperty()` / `$this->getStaticProperty()` helpers from `CoreSurfaceTest` base.
+
+## Key constraints
+- PHP **8.2+** required (checked in `sdf/__init.php`).
+- `composer.lock` is gitignored.
+- `.php-cs-fixer.dist.php` only targets `sdf/` and `app/` dirs.
+- PHPStan level 5, excludes `tests/`, bootstraps framework constants via `phpstan-bootstrap.php`.
+- Error handlers in `app/handlers/errors.php` — functions `eh_pathNotFound`, `eh_methodNotAllowed`, `eh_errorHandler`.
+- Static files only served in development mode via `SDF_STATIC_MIMES` constant.
+
+## Code conventions
+- No `die`/`exit` in kernel/core (allowed in `sdf/cli` standalone CLI script).
+- File header docblocks with `@package`, `@subpackage`, `@file`, `@version`, `@author`, `@copyright`, `@license`, `@link`, `@since`, `@filesource`.
+- Class docblocks; method docblocks with `@param`, `@return`.
+- **No inline `//` comments in method bodies** — only docblocks.
+- PSR-7 implementations must be immutable (`with*` returns new instance); live alongside legacy mutable classes for BC.
+- Session `session_start()` deferred to first `get()`/`set()`.
+- Router stores static routes in separate hash map for O(1) exact-path matching.
+- Swagger routes auto-registered only in `development` environment.
+- `zircote/swagger-php` moved to `require-dev` — not loaded in production.
+- Configuration: `app/config/*.php` files set `$config['key'] = [...]`.
+- Run `composer dump-autoload -o --apcu` after adding new classes.
+
+## Router
+- `add(string $expression, string|callable $controller, string $method = "any")`.
+- Supports `@` syntax for namespaced controllers: `\SDF\Swagger\SwaggerController@spec`.
+- Supports callable controllers: `function() { ... }`.
+- Supports `/` syntax: `Dir/Controller/method`.
+- Static routes (no `{param}` tokens) stored in `$staticRoutes` for O(1) lookup.
+- Routes cached to `sys_get_temp_dir()/sdf_routes.cache` via `serialize`/`unserialize` with `allowed_classes=false`.
+
+## Auth
+- Guards: `SessionGuard` (session-based), `JwtGuard` (HS256 stateless JWT) with refresh token support.
+- Auth middleware: `AuthMiddleware` — rejects with 401 if no authenticated user.
+- Config: `app/config/auth.php`.
+
+## Middleware
+- `CsrfMiddleware` — per-session CSRF validation, 419 on mismatch. Token via `X-CSRF-TOKEN` header or `_token` POST field.
+- `CorsMiddleware` — configurable origins/methods/headers, OPTIONS → 204. Wildcard+credentials echoes request Origin + `Vary: Origin`.
+- `RateLimitMiddleware` — per-IP/route via Cache, 429 with `Retry-After`. Malformed entries rebuilt.
+- `AuthMiddleware` — requires authenticated session/token.
+
+## Key implementations
+- `sdf/core/Env.php`: `.env` loader (KV parsing, quotes, `${VAR}` placeholders, circular reference guard).
+- `sdf/core/helpers.php`: Global `env()`, `csrf_token()`, `csrf_field()` helpers.
+- `sdf/core/Encryption/Encrypter.php`: AES-256-CBC + HMAC-SHA256 encrypt-then-MAC.
+- `sdf/core/Validation/Validator.php`: 19 rules (required, email, min, max, between, numeric, integer, string, boolean, array, alpha, alpha_num, url, in, confirmed, same, different, regex, nullable), custom messages, aliases, custom rules.
+- `sdf/core/Spark/Model.php`: ORM with `hasOne()`, `hasMany()`, `belongsTo()`, `belongsToMany()`.
+- `sdf/core/Spark/Paginator.php`: Pagination result class.
+- `sdf/core/Spark.php`: QueryBuilder with `select()`, `join()`, `paginate()`, `where()` LSB fix.
+
+## Performance
+- FrankenPHP `v1.11.2` (Homebrew) on PHP 8.5.3: ~10k req/sec on home route (full stack with Fuse view).
+- Redis SCAN instead of KEYS for cache clear.
+- RateLimitMiddleware stores raw arrays (not JSON strings) to avoid double-serialization.
+- SwaggerController echos JSON directly (no decode/encode cycle).
+- Config caching uses raw file (`sdf_config.cache`) to avoid circular dependency with Cache facade.
+- DB connection fully lazy: `Spark::ensureConnected()` auto-inits from config on first query.
+- Cache driver lazy-loaded in `resolveDriver()`.
+
+## Git
+- Only commit/amend/push when explicitly requested.
+- Before committing, inspect `git status`, `git diff`, `git log --oneline -10`; stage only intended files.
+- Write concise commit messages matching repo style.
+- Never force-push, skip hooks, or use interactive `-i`.
+
+When working on this codebase, always run tests before committing (`vendor/bin/phpunit --testdox`). If adding new classes, run `composer dump-autoload -o --apcu`.
+
+## Wiki
+Full documentation is at `wiki/`:
+- `wiki/libraries/` — lib docs (auth, cache, csrf, cors, ratelimit, encryption, validation, session, flash, request, http, swagger, benchmark).
+- `wiki/app/tutorials/` — tutorials (authentication, blog, docker-frankenphp).
+- `wiki/sdf/` — CLI docs.
+- `wiki/agentic_workflow/` — agentic development workflows.

--- a/wiki/agentic_workflow/tutorials/setup.md
+++ b/wiki/agentic_workflow/tutorials/setup.md
@@ -1,0 +1,55 @@
+# Agentic Setup Guide
+
+## Prerequisites
+
+- PHP 8.2+
+- Composer
+- (Optional) FrankenPHP — auto-detected by `sdf/cli serve`
+
+## Skill Integration
+
+The [project-sdf skill](../skills/project-sdf.md) is the single source of truth for agents working on this codebase. Load it at the start of each session:
+
+```bash
+# In opencode, load the skill file
+# The skill contains: commands, architecture, testing quirks, code conventions
+```
+
+## Agent Development Workflow
+
+1. **Load the project-sdf skill** — provides full codebase context
+2. **Explore** — use search tools to understand relevant files
+3. **Plan** — outline changes before implementation
+4. **Implement** — follow code conventions (no inline comments, docblocks required)
+5. **Test** — run `vendor/bin/phpunit --testdox` before committing
+6. **Lint** — run `composer analyze` (PHPStan) and `composer cs:check`
+7. **Commit** — concise message matching repo style
+
+## Directory Map
+
+```
+sdf/core/         → SDF\ namespace (framework core)
+sdf/core/Cache/   → PSR-16 Cache drivers
+sdf/core/Auth/    → Guards (SessionGuard, JwtGuard)
+sdf/core/Middleware/ → Csrf, Cors, RateLimit, Auth
+sdf/core/Encryption/ → Encrypter
+sdf/core/Validation/ → Validator
+sdf/core/Spark/   → ORM (Model, Paginator, Pool)
+sdf/core/Http/    → PSR-7 implementations
+sdf/core/Swagger/ → OpenAPI generator + controller
+app/config/       → Configuration files
+app/controllers/  → Application controllers
+app/views/        → Fuse/PHP view templates
+tests/            → PHPUnit tests (Tests\ namespace)
+wiki/             → Documentation
+```
+
+## Key Rules for Agents
+
+1. Always run tests before committing (`vendor/bin/phpunit --testdox`)
+2. No `die`/`exit` in kernel/core — allowed only in `sdf/cli`
+3. No inline `//` comments in method bodies — docblocks only
+4. File headers must include full docblock with `@package`, `@author`, etc.
+5. Reset static state in test `setUp`/`tearDown` (`Core::$config`, `Router::$routes`)
+6. For new classes, run `composer dump-autoload -o --apcu`
+7. Use `uniqid()` or reflection for test isolation (shared static state)

--- a/wiki/app/handlers.md
+++ b/wiki/app/handlers.md
@@ -2,7 +2,7 @@
 
 This is the documentation for the handlers in the app. Here you can find all the information you need to get started.
 
-> Handlers provide small, reusable functions that the framework or your controllers can call — for example custom error handlers, global utility functions, or boot-time callbacks. This section documents handler conventions, recommended function signatures, how to register/load handlers from `app/handlers/`, and common examples you can copy and adapt. If you need additional examples or integrations, please open an issue.
+> Handlers provide small, reusable functions that the framework or your controllers can call - for example custom error handlers, global utility functions, or boot-time callbacks. This section documents handler conventions, recommended function signatures, how to register/load handlers from `app/handlers/`, and common examples you can copy and adapt. If you need additional examples or integrations, please open an issue.
 
 ## Basic Handler
 

--- a/wiki/app/tutorials/authentication.md
+++ b/wiki/app/tutorials/authentication.md
@@ -84,7 +84,8 @@ class AuthController extends Controller
         $password = $this->request->post('password');
 
         if (Auth::attempt(['email' => $email, 'password' => $password])) {
-            Flash::set('success', 'Welcome back!');
+            $flash = new \SDF\Flash();
+            $flash->set('success', 'Welcome back!');
             $this->response->redirect('/dashboard');
         } else {
             $this->fuse
@@ -97,7 +98,8 @@ class AuthController extends Controller
     public function logout(): void
     {
         Auth::logout();
-        Flash::set('info', 'You have been logged out.');
+        $flash = new \SDF\Flash();
+        $flash->set('info', 'You have been logged out.');
         $this->response->redirect('/login');
     }
 
@@ -117,7 +119,8 @@ class AuthController extends Controller
             'password' => password_hash($body['password'], PASSWORD_BCRYPT),
         ]);
 
-        Flash::set('success', 'Account created! Please log in.');
+        $flash = new \SDF\Flash();
+        $flash->set('success', 'Account created! Please log in.');
         $this->response->redirect('/login');
     }
 }
@@ -193,7 +196,7 @@ Display flash messages in your base layout or login view:
   @endIf
 
   <h1>Dashboard</h1>
-  <p>Hello, {{ $user['name'] ?? 'User' }}!</p>
+  <p>Hello, {{ $user->name ?? 'User' }}!</p>
   <a href="/logout">Logout</a>
 </body>
 </html>

--- a/wiki/app/tutorials/authentication.md
+++ b/wiki/app/tutorials/authentication.md
@@ -1,6 +1,8 @@
 # Tutorial: User Authentication
 
-Implement session-based login, route protection with `AuthMiddleware`, and user registration using the built-in Auth library.
+Implement session-based login, route protection with `AuthMiddleware`, user registration, and flash messages using the built-in Auth and Flash libraries.
+
+---
 
 ## 1. Users Migration
 
@@ -37,6 +39,8 @@ class create_users_table_20240510000002
 php sdf/cli db migrate
 ```
 
+---
+
 ## 2. User Model
 
 `app/models/User.php`:
@@ -52,6 +56,8 @@ class User extends Model
 }
 ```
 
+---
+
 ## 3. Auth Controller
 
 `app/controllers/AuthController.php`:
@@ -61,6 +67,7 @@ class User extends Model
 
 use SDF\Auth\Auth;
 use SDF\Controller;
+use SDF\Flash;
 
 class AuthController extends Controller
 {
@@ -77,6 +84,7 @@ class AuthController extends Controller
         $password = $this->request->post('password');
 
         if (Auth::attempt(['email' => $email, 'password' => $password])) {
+            Flash::set('success', 'Welcome back!');
             $this->response->redirect('/dashboard');
         } else {
             $this->fuse
@@ -89,6 +97,7 @@ class AuthController extends Controller
     public function logout(): void
     {
         Auth::logout();
+        Flash::set('info', 'You have been logged out.');
         $this->response->redirect('/login');
     }
 
@@ -108,10 +117,13 @@ class AuthController extends Controller
             'password' => password_hash($body['password'], PASSWORD_BCRYPT),
         ]);
 
+        Flash::set('success', 'Account created! Please log in.');
         $this->response->redirect('/login');
     }
 }
 ```
+
+---
 
 ## 4. Protected Controller with AuthMiddleware
 
@@ -122,16 +134,20 @@ class AuthController extends Controller
 
 use SDF\Auth\Auth;
 use SDF\Controller;
+use SDF\Flash;
 
 class Dashboard extends Controller
 {
     public function index(): void
     {
         $user = Auth::user();
-        $this->fuse->with(compact('user'))->render('dashboard/index');
+        $flash = Flash::all();
+        $this->fuse->with(compact('user', 'flash'))->render('dashboard/index');
     }
 }
 ```
+
+---
 
 ## 5. AuthMiddleware (built-in)
 
@@ -143,7 +159,10 @@ Register it in your route config:
 <?php
 // app/config/routes.php
 
-Router::middleware(\SDF\Auth\AuthMiddleware::class);
+use SDF\Auth\AuthMiddleware;
+use SDF\Router;
+
+Router::middleware(AuthMiddleware::class);
 
 // All routes below require authentication
 $config['/dashboard'] = 'Dashboard/index';
@@ -155,33 +174,41 @@ $config['/logout']    = ['AuthController/logout',    'GET'];
 $config['/register']  = ['AuthController/register',  'POST'];
 ```
 
-## 6. Login View
+---
 
-`app/views/auth/login.php`:
+## 6. Flash Messages in Views
+
+Display flash messages in your base layout or login view:
 
 ```html
+<!-- app/views/dashboard/index.php -->
 <!doctype html>
 <html lang="en">
-<head><title>Login</title></head>
+<head><title>Dashboard</title></head>
 <body>
-  @If(isset($error))
-    <p style="color:red">{{ $error }}</p>
+  @If(!empty($flash))
+    @Foreach($flash as $type => $message)
+      <p class="flash flash-{{ $type }}">{{ $message }}</p>
+    @endForeach
   @endIf
 
-  <form method="POST" action="/login">
-    <label>Email <input type="email" name="email" required></label>
-    <label>Password <input type="password" name="password" required></label>
-    <button type="submit">Log In</button>
-  </form>
+  <h1>Dashboard</h1>
+  <p>Hello, {{ $user['name'] ?? 'User' }}!</p>
+  <a href="/logout">Logout</a>
 </body>
 </html>
 ```
 
-## 7. Routes
+---
+
+## 7. Full Routes File
 
 ```php
 <?php
 // app/config/routes.php
+
+use SDF\Auth\AuthMiddleware;
+use SDF\Router;
 
 // Public routes
 $config['/login']     = ['AuthController/loginForm', 'GET'];
@@ -190,13 +217,16 @@ $config['/logout']    = ['AuthController/logout',    'GET'];
 $config['/register']  = ['AuthController/register',  'POST'];
 
 // Protected routes
-Router::middleware(\SDF\Auth\AuthMiddleware::class);
+Router::middleware(AuthMiddleware::class);
 $config['/dashboard'] = 'Dashboard/index';
 ```
+
+---
 
 ## What You Learned
 
 - Using `Auth::attempt()` for credential-based login
 - Using `Auth::user()` to get the authenticated model
 - Protecting routes with `AuthMiddleware`
-- Registering middleware before protected routes
+- Sending flash messages with `SDF\Flash` across redirects
+- Using `Session` (auto-started) for underlying state management

--- a/wiki/app/tutorials/authentication.md
+++ b/wiki/app/tutorials/authentication.md
@@ -223,6 +223,20 @@ $config['/dashboard'] = 'Dashboard/index';
 
 ---
 
+## New Feature Integration
+
+**CSRF protection** — Protect login/registration forms by registering `CsrfMiddleware` and using the `@csrf` helper in Fuse templates:
+```php
+Router::middleware(\SDF\Middleware\CsrfMiddleware::class);
+```
+
+**Env-based JWT secret** — Store your JWT signing key in `.env` and load it securely:
+```php
+$secret = \SDF\Env::get('JWT_SECRET');
+```
+
+---
+
 ## What You Learned
 
 - Using `Auth::attempt()` for credential-based login

--- a/wiki/app/tutorials/authentication.md
+++ b/wiki/app/tutorials/authentication.md
@@ -1,8 +1,6 @@
 # Tutorial: User Authentication
 
-Implement session-based login, a Guard to protect routes, and an auth middleware.
-
----
+Implement session-based login, route protection with `AuthMiddleware`, and user registration using the built-in Auth library.
 
 ## 1. Users Migration
 
@@ -22,7 +20,7 @@ class create_users_table_20240510000002
                 id            INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
                 name          VARCHAR(120) NOT NULL,
                 email         VARCHAR(255) NOT NULL UNIQUE,
-                password_hash VARCHAR(255) NOT NULL,
+                password      VARCHAR(255) NOT NULL,
                 created_at    TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             )
         ");
@@ -39,8 +37,6 @@ class create_users_table_20240510000002
 php sdf/cli db migrate
 ```
 
----
-
 ## 2. User Model
 
 `app/models/User.php`:
@@ -53,16 +49,8 @@ use SDF\Spark\Model;
 class User extends Model
 {
     protected static string $table = 'users';
-
-    public static function findByEmail(string $email): ?array
-    {
-        $rows = self::query()->where('email', '=', $email)->get();
-        return $rows[0] ?? null;
-    }
 }
 ```
-
----
 
 ## 3. Auth Controller
 
@@ -71,6 +59,7 @@ class User extends Model
 ```php
 <?php
 
+use SDF\Auth\Auth;
 use SDF\Controller;
 
 class AuthController extends Controller
@@ -84,38 +73,23 @@ class AuthController extends Controller
     /** POST /login — authenticate */
     public function login(): void
     {
-        session_start();
-
         $email    = $this->request->post('email');
         $password = $this->request->post('password');
 
-        $user = User::findByEmail($email);
-
-        if (!$user || !password_verify($password, $user['password_hash'])) {
+        if (Auth::attempt(['email' => $email, 'password' => $password])) {
+            $this->response->redirect('/dashboard');
+        } else {
             $this->fuse
                 ->with('error', 'Invalid email or password.')
                 ->render('auth/login');
-            return;
         }
-
-        // Store minimal user data in session
-        $_SESSION['user'] = [
-            'id'    => $user['id'],
-            'name'  => $user['name'],
-            'email' => $user['email'],
-        ];
-
-        header('Location: /dashboard');
-        exit;
     }
 
     /** GET /logout */
     public function logout(): void
     {
-        session_start();
-        session_destroy();
-        header('Location: /login');
-        exit;
+        Auth::logout();
+        $this->response->redirect('/login');
     }
 
     /** POST /register */
@@ -129,69 +103,57 @@ class AuthController extends Controller
         }
 
         User::query()->insert([
-            'name'          => $body['name'],
-            'email'         => $body['email'],
-            'password_hash' => password_hash($body['password'], PASSWORD_BCRYPT),
+            'name'     => $body['name'],
+            'email'    => $body['email'],
+            'password' => password_hash($body['password'], PASSWORD_BCRYPT),
         ]);
 
-        header('Location: /login');
-        exit;
+        $this->response->redirect('/login');
     }
 }
 ```
 
----
+## 4. Protected Controller with AuthMiddleware
 
-## 4. Auth Guard
-
-`app/guards/AuthGuard.php`:
+`app/controllers/Dashboard.php`:
 
 ```php
 <?php
 
-use SDF\Guard;
-use SDF\Request;
-
-class AuthGuard extends Guard
-{
-    public function authorize(Request $request): bool
-    {
-        session_start();
-        return isset($_SESSION['user']);
-    }
-}
-```
-
----
-
-## 5. Protected Controller
-
-Any controller that needs auth applies the guard:
-
-```php
-<?php
-
+use SDF\Auth\Auth;
 use SDF\Controller;
 
 class Dashboard extends Controller
 {
     public function index(): void
     {
-        $guard = new AuthGuard();
-        if (!$guard->authorize($this->request)) {
-            header('Location: /login');
-            exit;
-        }
-
-        session_start();
-        $user = $_SESSION['user'];
-
+        $user = Auth::user();
         $this->fuse->with(compact('user'))->render('dashboard/index');
     }
 }
 ```
 
----
+## 5. AuthMiddleware (built-in)
+
+The framework ships with `SDF\Auth\AuthMiddleware`. It checks the session guard and throws a 401 if unauthenticated.
+
+Register it in your route config:
+
+```php
+<?php
+// app/config/routes.php
+
+Router::middleware(\SDF\Auth\AuthMiddleware::class);
+
+// All routes below require authentication
+$config['/dashboard'] = 'Dashboard/index';
+
+// Routes registered before middleware are public
+$config['/login']     = ['AuthController/loginForm', 'GET'];
+$config['/login']     = ['AuthController/login',     'POST'];
+$config['/logout']    = ['AuthController/logout',    'GET'];
+$config['/register']  = ['AuthController/register',  'POST'];
+```
 
 ## 6. Login View
 
@@ -215,26 +177,26 @@ class Dashboard extends Controller
 </html>
 ```
 
----
-
 ## 7. Routes
 
 ```php
 <?php
 // app/config/routes.php
 
+// Public routes
 $config['/login']     = ['AuthController/loginForm', 'GET'];
 $config['/login']     = ['AuthController/login',     'POST'];
 $config['/logout']    = ['AuthController/logout',    'GET'];
 $config['/register']  = ['AuthController/register',  'POST'];
+
+// Protected routes
+Router::middleware(\SDF\Auth\AuthMiddleware::class);
 $config['/dashboard'] = 'Dashboard/index';
 ```
 
----
-
 ## What You Learned
 
-- Storing hashed passwords with `password_hash` / `password_verify`
-- Session management in SDF controllers
-- Using a `Guard` to protect any controller method
-- Rendering login errors via Fuse template variables
+- Using `Auth::attempt()` for credential-based login
+- Using `Auth::user()` to get the authenticated model
+- Protecting routes with `AuthMiddleware`
+- Registering middleware before protected routes

--- a/wiki/app/tutorials/authentication.md
+++ b/wiki/app/tutorials/authentication.md
@@ -71,13 +71,13 @@ use SDF\Flash;
 
 class AuthController extends Controller
 {
-    /** GET /login — show form */
+    /** GET /login - show form */
     public function loginForm(): void
     {
         $this->fuse->render('auth/login');
     }
 
-    /** POST /login — authenticate */
+    /** POST /login - authenticate */
     public function login(): void
     {
         $email    = $this->request->post('email');

--- a/wiki/app/tutorials/blog.md
+++ b/wiki/app/tutorials/blog.md
@@ -252,6 +252,28 @@ class PostController extends Controller
 
 ---
 
+## New Feature Integration
+
+**CSRF protection** — Add `CsrfMiddleware` to your admin routes and include `@csrf` in Fuse forms:
+```php
+Router::middleware(\SDF\Middleware\CsrfMiddleware::class);
+```
+
+**Env-based DB config** — Set database credentials in `.env` and load them via `\SDF\Env::get()`:
+```php
+$config['db'] = [
+    'host' => \SDF\Env::get('DB_HOST'),
+    'name' => \SDF\Env::get('DB_NAME'),
+];
+```
+
+**Encryption** — Encrypt sensitive fields (e.g., user emails) with `\SDF\Encryption\Encrypter`:
+```php
+$encrypted = \SDF\Encryption\Encrypter::encrypt($email);
+```
+
+---
+
 ## What You Learned
 
 - Full MVC lifecycle in SDF

--- a/wiki/app/tutorials/blog.md
+++ b/wiki/app/tutorials/blog.md
@@ -160,11 +160,12 @@ class PostController extends Controller
             'excerpt' => $body['excerpt'] ?? '',
             'content' => $body['content'],
             'status'  => $body['status'] ?? 'draft',
-            'user_id' => Auth::user()['id'],
+            'user_id' => Auth::user()->id,
         ]);
 
         Cache::forget('blog.published');
-        Flash::set('success', 'Post created!');
+        $flash = new \SDF\Flash();
+        $flash->set('success', 'Post created!');
         $this->response->redirect('/');
     }
 
@@ -188,7 +189,8 @@ class PostController extends Controller
         $stmt->execute([$body['title'], $body['content'], $body['status'], $id]);
 
         Cache::forget('blog.published');
-        Flash::set('success', 'Post updated!');
+        $flash = new \SDF\Flash();
+        $flash->set('success', 'Post updated!');
         $this->response->json(['updated' => true]);
     }
 
@@ -199,7 +201,8 @@ class PostController extends Controller
         $stmt->execute([$id]);
 
         Cache::forget('blog.published');
-        Flash::set('info', 'Post deleted.');
+        $flash = new \SDF\Flash();
+        $flash->set('info', 'Post deleted.');
         $this->response->status(204)->json([]);
     }
 }

--- a/wiki/app/tutorials/blog.md
+++ b/wiki/app/tutorials/blog.md
@@ -1,6 +1,6 @@
 # Tutorial: Blog Application
 
-Full end-to-end blog: routes, Spark ORM, controllers, and Fuse templates.
+Full end-to-end blog: routes, Spark ORM, controllers, Fuse templates, Auth, Flash, Session, and Cache.
 
 ---
 
@@ -78,8 +78,15 @@ class Post extends Model
 <?php
 // app/config/routes.php
 
+use SDF\Auth\AuthMiddleware;
+use SDF\Router;
+
+// Public routes
 $config['/']                = 'Blog/index';
 $config['/post/{url}']      = ['Blog/show',   'GET'];
+
+// Admin routes (protected)
+Router::middleware(AuthMiddleware::class);
 $config['/admin/post']      = ['Admin\PostController/create', 'GET'];
 $config['/admin/post']      = ['Admin\PostController/store',  'POST'];
 $config['/admin/post/{id}'] = ['Admin\PostController/edit',   'GET'];
@@ -96,13 +103,16 @@ $config['/admin/post/{id}'] = ['Admin\PostController/destroy','DELETE'];
 ```php
 <?php
 
+use SDF\Cache\Cache;
 use SDF\Controller;
 
 class Blog extends Controller
 {
     public function index(): void
     {
-        $posts = Post::published();
+        $posts = Cache::remember('blog.published', 300, function () {
+            return Post::published();
+        });
         $this->fuse->with(compact('posts'))->render('blog/index');
     }
 
@@ -127,7 +137,10 @@ class Blog extends Controller
 ```php
 <?php
 
+use SDF\Auth\Auth;
+use SDF\Cache\Cache;
 use SDF\Controller;
+use SDF\Flash;
 
 class PostController extends Controller
 {
@@ -138,7 +151,7 @@ class PostController extends Controller
 
     public function store(): void
     {
-        $body = $_POST;
+        $body = $this->request->body() ?: $_POST;
         $slug = strtolower(preg_replace('/[^a-zA-Z0-9]+/', '-', $body['title']));
 
         Post::query()->insert([
@@ -147,11 +160,12 @@ class PostController extends Controller
             'excerpt' => $body['excerpt'] ?? '',
             'content' => $body['content'],
             'status'  => $body['status'] ?? 'draft',
-            'user_id' => $_SESSION['user']['id'],
+            'user_id' => Auth::user()['id'],
         ]);
 
-        header('Location: /');
-        exit;
+        Cache::forget('blog.published');
+        Flash::set('success', 'Post created!');
+        $this->response->redirect('/');
     }
 
     public function edit(int $id): void
@@ -172,6 +186,9 @@ class PostController extends Controller
             'UPDATE posts SET title=?, content=?, status=? WHERE id=?'
         );
         $stmt->execute([$body['title'], $body['content'], $body['status'], $id]);
+
+        Cache::forget('blog.published');
+        Flash::set('success', 'Post updated!');
         $this->response->json(['updated' => true]);
     }
 
@@ -180,6 +197,9 @@ class PostController extends Controller
         $pdo  = \SDF\Spark::pdo();
         $stmt = $pdo->prepare('DELETE FROM posts WHERE id = ?');
         $stmt->execute([$id]);
+
+        Cache::forget('blog.published');
+        Flash::set('info', 'Post deleted.');
         $this->response->status(204)->json([]);
     }
 }
@@ -239,3 +259,6 @@ class PostController extends Controller
 - Slug generation from titles
 - Admin vs public controller separation via subdirectories
 - Fuse `@Foreach` + `@If` in real templates
+- Caching the published listing with `Cache::remember()` and invalidating on mutation
+- Using `Auth::user()` instead of `$_SESSION` superglobals
+- Sending flash messages with `SDF\Flash` across redirects

--- a/wiki/app/tutorials/custom-middleware.md
+++ b/wiki/app/tutorials/custom-middleware.md
@@ -1,6 +1,6 @@
 # Tutorial: Custom Middleware
 
-Build three practical middlewares: rate limiting, CORS headers, and request logging.
+Build three practical middlewares: rate limiting (via Cache facade), CORS headers, and request logging.
 
 ---
 
@@ -61,17 +61,21 @@ class CorsMiddleware implements Middleware
 }
 ```
 
+> **PSR-7/PSR-15 alternative:** For a framework-agnostic middleware pipeline, implement `Psr\Http\Server\MiddlewareInterface`
+> and use `ServerRequestInterface`/`ResponseInterface` instead of reading `$_SERVER` superglobals.
+
 ---
 
 ## 2. Rate Limit Middleware
 
-Limits each IP to N requests per minute using file-based counters (swap for Redis in production).
+Limits each IP to N requests per minute using the **Cache facade** — swap drivers (`file`/`redis`/`memcached`) via config without changing code.
 
 `app/middlewares/RateLimitMiddleware.php`:
 
 ```php
 <?php
 
+use SDF\Cache\Cache;
 use SDF\Middleware;
 use SDF\Request;
 
@@ -81,22 +85,20 @@ class RateLimitMiddleware implements Middleware
 
     public function handle(Request $request, \Closure $next): mixed
     {
-        $ip        = $_SERVER['REMOTE_ADDR'] ?? '0.0.0.0';
-        $cacheFile = sys_get_temp_dir() . '/rl_' . md5($ip) . '.json';
+        $ip  = $_SERVER['REMOTE_ADDR'] ?? '0.0.0.0';
+        $key = 'rate_limit:' . md5($ip);
 
-        $data = file_exists($cacheFile)
-            ? json_decode(file_get_contents($cacheFile), true)
-            : null;
+        $data = Cache::get($key, ['count' => 0, 'window' => time()]);
 
         $now = time();
 
-        if (!$data || ($now - $data['window']) >= 60) {
+        if (($now - $data['window']) >= 60) {
             $data = ['count' => 1, 'window' => $now];
         } else {
             $data['count']++;
         }
 
-        file_put_contents($cacheFile, json_encode($data));
+        Cache::set($key, $data, 120);
 
         header('X-RateLimit-Limit: ' . $this->limit);
         header('X-RateLimit-Remaining: ' . max(0, $this->limit - $data['count']));
@@ -112,6 +114,9 @@ class RateLimitMiddleware implements Middleware
     }
 }
 ```
+
+> **Why Cache?** The `Cache` facade abstracts file/Redis/Memcached behind the same API.
+> Switch to Redis in production just by changing `app/config/cache.php` — no code changes.
 
 ---
 
@@ -184,6 +189,7 @@ $response = (new Pipeline)
 
 - Implementing the `SDF\Middleware` interface
 - CORS preflight handling
-- File-based rate limiting with sliding window
+- Rate limiting with the `Cache` facade (driver-agnostic)
 - Measuring and logging response times via middleware wrap
 - Chaining multiple middlewares in `Pipeline::through()`
+- The built-in `SDF\Auth\AuthMiddleware` for route authentication

--- a/wiki/app/tutorials/custom-middleware.md
+++ b/wiki/app/tutorials/custom-middleware.md
@@ -68,7 +68,7 @@ class CorsMiddleware implements Middleware
 
 ## 2. Rate Limit Middleware
 
-Limits each IP to N requests per minute using the **Cache facade** — swap drivers (`file`/`redis`/`memcached`) via config without changing code.
+Limits each IP to N requests per minute using the **Cache facade** - swap drivers (`file`/`redis`/`memcached`) via config without changing code.
 
 `app/middlewares/RateLimitMiddleware.php`:
 
@@ -116,7 +116,7 @@ class RateLimitMiddleware implements Middleware
 ```
 
 > **Why Cache?** The `Cache` facade abstracts file/Redis/Memcached behind the same API.
-> Switch to Redis in production just by changing `app/config/cache.php` — no code changes.
+> Switch to Redis in production just by changing `app/config/cache.php` - no code changes.
 
 ---
 
@@ -141,7 +141,7 @@ class LogMiddleware implements Middleware
         $ms    = round((microtime(true) - $start) * 1000, 3);
 
         $line = sprintf(
-            "[%s] %s %s — %sms from %s\n",
+            "[%s] %s %s - %sms from %s\n",
             date('Y-m-d H:i:s'),
             $_SERVER['REQUEST_METHOD'],
             $_SERVER['REQUEST_URI'],

--- a/wiki/app/tutorials/custom-middleware.md
+++ b/wiki/app/tutorials/custom-middleware.md
@@ -185,6 +185,24 @@ $response = (new Pipeline)
 
 ---
 
+## New Feature Integration
+
+SDF now ships with three built-in middleware classes — `CsrfMiddleware`, `CorsMiddleware`, and `RateLimitMiddleware` — all under the `SDF\Middleware` namespace. Import and register them directly instead of rolling your own:
+
+```php
+use SDF\Middleware\CorsMiddleware;
+use SDF\Middleware\RateLimitMiddleware;
+use SDF\Middleware\CsrfMiddleware;
+
+Router::middleware(CorsMiddleware::class);
+Router::middleware(RateLimitMiddleware::class);
+Router::middleware(CsrfMiddleware::class);
+```
+
+The custom implementations above remain useful as a reference, but the built-in versions are recommended for new projects.
+
+---
+
 ## What You Learned
 
 - Implementing the `SDF\Middleware` interface

--- a/wiki/app/tutorials/docker-frankenphp.md
+++ b/wiki/app/tutorials/docker-frankenphp.md
@@ -1,6 +1,6 @@
 # Deploying SDF with Docker & FrankenPHP
 
-[FrankenPHP](https://frankenphp.dev/) is a modern PHP application server built on top of Caddy. It provides automatic HTTPS, HTTP/2, HTTP/3, worker mode, and a production-ready PHP runtime — no separate web server or PHP-FPM needed.
+[FrankenPHP](https://frankenphp.dev/) is a modern PHP application server built on top of Caddy. It provides automatic HTTPS, HTTP/2, HTTP/3, worker mode, and a production-ready PHP runtime - no separate web server or PHP-FPM needed.
 
 ## Project Structure
 
@@ -61,7 +61,7 @@ ENV APP_ENV=prod
 EXPOSE 80 443
 
 # FrankenPHP automatically serves index.php from /app/public
-# SDF uses index.php in the root — configure Caddy to match
+# SDF uses index.php in the root - configure Caddy to match
 CMD ["frankenphp", "run", "--config", "/app/Caddyfile"]
 ```
 
@@ -200,7 +200,7 @@ FrankenPHP can run PHP in worker mode for better performance. Create a `frankenp
 ```php
 <?php
 // frankenphp-worker.php
-// FrankenPHP worker script — runs once and handles multiple requests
+// FrankenPHP worker script - runs once and handles multiple requests
 
 const SDF = true;
 const SDF_ENV = 'production';

--- a/wiki/app/tutorials/docker-frankenphp.md
+++ b/wiki/app/tutorials/docker-frankenphp.md
@@ -2,6 +2,8 @@
 
 [FrankenPHP](https://frankenphp.dev/) is a modern PHP application server built on top of Caddy. It provides automatic HTTPS, HTTP/2, HTTP/3, worker mode, and a production-ready PHP runtime - no separate web server or PHP-FPM needed.
 
+The SDF CLI (`sdf/cli serve`) auto-detects FrankenPHP — if the `frankenphp` binary is found, it runs `frankenphp php-server`, otherwise falls back to the PHP built-in server.
+
 ## Project Structure
 
 ```

--- a/wiki/app/tutorials/docker-frankenphp.md
+++ b/wiki/app/tutorials/docker-frankenphp.md
@@ -1,0 +1,248 @@
+# Deploying SDF with Docker & FrankenPHP
+
+[FrankenPHP](https://frankenphp.dev/) is a modern PHP application server built on top of Caddy. It provides automatic HTTPS, HTTP/2, HTTP/3, worker mode, and a production-ready PHP runtime — no separate web server or PHP-FPM needed.
+
+## Project Structure
+
+```
+project-sdf/
+├── app/                  # Application code (config, controllers, views, ...)
+├── sdf/                  # Framework core
+├── index.php             # Application entrypoint
+├── Dockerfile
+├── compose.yaml
+└── .dockerignore
+```
+
+## Dockerfile
+
+Create a `Dockerfile` in the project root:
+
+```dockerfile
+FROM dunglas/frankenphp:1-php8.4 AS base
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    unzip \
+    libicu-dev \
+    libpq-dev \
+    libsqlite3-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install PHP extensions
+RUN install-php-extensions \
+    pdo_mysql \
+    pdo_pgsql \
+    pdo_sqlite \
+    pdo_sqlsrv \
+    intl \
+    opcache
+
+# Install Composer
+COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+
+# Copy project files
+WORKDIR /app
+COPY . .
+
+# Install dependencies (production only)
+RUN composer install --no-dev --optimize-autoloader --no-interaction
+
+# Hardened permissions
+RUN chown -R www-data:www-data /app/app/cache /app/logs 2>/dev/null || true
+
+# ─── Production stage ─────────────────────────────────────────────────────────
+FROM base AS production
+
+ENV SDF_ENV=production
+ENV APP_ENV=prod
+
+EXPOSE 80 443
+
+# FrankenPHP automatically serves index.php from /app/public
+# SDF uses index.php in the root — configure Caddy to match
+CMD ["frankenphp", "run", "--config", "/app/Caddyfile"]
+```
+
+## Caddyfile / FrankenPHP config
+
+Create a `Caddyfile` in the project root:
+
+```caddyfile
+{
+    # Global options
+    frankenphp
+}
+
+localhost:80 {
+    root * /app
+    php {
+        resolve_root_symlink
+    }
+
+    # Serve static files directly
+    @static {
+        file {
+            try_files {path} {path}/index.php
+        }
+    }
+    rewrite @static {path}
+
+    # Default SDF entrypoint
+    try_files {path} /index.php
+
+    # Security headers
+    header {
+        X-Content-Type-Options "nosniff"
+        X-Frame-Options "DENY"
+        X-XSS-Protection "1; mode=block"
+        Referrer-Policy "strict-origin-when-cross-origin"
+        -Server
+    }
+
+    # Hide sensitive paths
+    respond /app/config/* 403
+    respond /app/cache/* 403
+    respond /sdf/* 403
+    respond /vendor/* 403
+    respond /composer.json 403
+    respond /composer.lock 403
+}
+
+# Optional: HTTPS with automatic certificates (production)
+# example.com {
+#     root * /app
+#     php { resolve_root_symlink }
+#     try_files {path} /index.php
+# }
+```
+
+## Compose file
+
+Create a `compose.yaml` for local development or production:
+
+```yaml
+services:
+  app:
+    build:
+      context: .
+      target: production
+    ports:
+      - "80:80"
+      - "443:443"
+    environment:
+      - SDF_ENV=production
+    volumes:
+      # Mount config and uploads for persistent data
+      - ./app/config:/app/app/config:ro
+      - ./uploads:/app/uploads
+    restart: unless-stopped
+```
+
+## .dockerignore
+
+```
+.git/
+.gitignore
+tests/
+wiki/
+*.md
+.phpunit*
+.php-cs-fixer*
+phpstan*
+.DS_Store
+docker-compose*
+compose.override.yaml
+```
+
+## Environment & Config
+
+Configure `app/config/app.php` for production:
+
+```php
+<?php
+$config["rc_magic_routing"] = false;       // disable magic routing in production
+$config["app_version"] = "v1.0";
+$config["app_title"] = "My SDF Application";
+```
+
+Set the cache driver to Redis or file in `app/config/cache.php`:
+
+```php
+<?php
+$config['cache'] = [
+    'driver' => 'file', // or 'redis'
+    'file' => [
+        'path' => '/tmp/sdf_cache/',
+        'prefix' => 'sdf_cache_',
+    ],
+];
+```
+
+## Building & Running
+
+```bash
+# Build the image
+docker build -t my-sdf-app .
+
+# Run with Compose
+docker compose up -d
+
+# Run directly
+docker run -d --name my-sdf-app -p 80:80 -p 443:443 my-sdf-app
+```
+
+## Worker Mode (FrankenPHP)
+
+FrankenPHP can run PHP in worker mode for better performance. Create a `frankenphp-worker.php` entrypoint:
+
+```php
+<?php
+// frankenphp-worker.php
+// FrankenPHP worker script — runs once and handles multiple requests
+
+const SDF = true;
+const SDF_ENV = 'production';
+
+require __DIR__ . '/index.php';
+```
+
+Then update the `Caddyfile` to enable worker mode:
+
+```caddyfile
+localhost:80 {
+    root * /app
+    php {
+        resolve_root_symlink
+        worker frankenphp-worker.php 4  # 4 workers
+    }
+    try_files {path} /index.php
+}
+```
+
+## Performance Tuning
+
+### OPcache (recommended)
+
+Create `app/php.ini` and mount it, or add to `Caddyfile`:
+
+```ini
+opcache.enable=1
+opcache.memory_consumption=128
+opcache.max_accelerated_files=10000
+opcache.revalidate_freq=0
+opcache.validate_timestamps=0
+opcache.fast_shutdown=1
+```
+
+### FrankenPHP tuning
+
+```caddyfile
+{
+    frankenphp
+    # Tune for your workload
+    max_request_body_size 10485760  # 10 MB
+    request_timeout 30s
+}
+```

--- a/wiki/app/tutorials/file-upload.md
+++ b/wiki/app/tutorials/file-upload.md
@@ -25,6 +25,7 @@ $config['/files/{url}'] = ['UploadController/serve',  'GET'];
 <?php
 
 use SDF\Controller;
+use SDF\Http\UploadedFile;
 
 class UploadController extends Controller
 {
@@ -39,22 +40,32 @@ class UploadController extends Controller
 
     public function store(): void
     {
-        if (empty($_FILES['file'])) {
+        // Use PSR-7 UploadedFile from fromGlobals()
+        $psrRequest  = \SDF\Http\ServerRequest::fromGlobals();
+        $uploaded    = $psrRequest->getUploadedFiles()['file'] ?? null;
+
+        if (!$uploaded || $uploaded->getError() !== UPLOAD_ERR_OK) {
             $this->response->status(400)->json(['error' => 'No file uploaded']);
             return;
         }
 
-        $file = $_FILES['file'];
-
         // Validate size
-        if ($file['size'] > self::MAX_SIZE) {
+        if ($uploaded->getSize() > self::MAX_SIZE) {
             $this->response->status(413)->json(['error' => 'File too large (max 5 MB)']);
             return;
         }
 
         // Validate MIME — use finfo, not $_FILES['type'] (spoofable)
+        $stream   = $uploaded->getStream();
+        $tmpPath  = stream_get_meta_data($stream->detach())['uri'] ?? null;
+
+        if (!$tmpPath) {
+            $this->response->status(500)->json(['error' => 'Unable to read upload']);
+            return;
+        }
+
         $finfo    = new \finfo(FILEINFO_MIME_TYPE);
-        $mimeType = $finfo->file($file['tmp_name']);
+        $mimeType = $finfo->file($tmpPath);
 
         if (!in_array($mimeType, self::ALLOWED, true)) {
             $this->response->status(415)->json([
@@ -65,7 +76,7 @@ class UploadController extends Controller
         }
 
         // Build safe filename
-        $ext      = pathinfo($file['name'], PATHINFO_EXTENSION);
+        $ext      = pathinfo($uploaded->getClientFilename(), PATHINFO_EXTENSION);
         $filename = bin2hex(random_bytes(16)) . '.' . strtolower($ext);
         $dest     = self::UPLOAD_DIR . $filename;
 
@@ -73,15 +84,12 @@ class UploadController extends Controller
             mkdir(self::UPLOAD_DIR, 0755, true);
         }
 
-        if (!move_uploaded_file($file['tmp_name'], $dest)) {
-            $this->response->status(500)->json(['error' => 'Upload failed']);
-            return;
-        }
+        $uploaded->moveTo($dest);
 
         $this->response->status(201)->json([
             'file' => $filename,
             'url'  => '/files/' . $filename,
-            'size' => $file['size'],
+            'size' => $uploaded->getSize(),
             'type' => $mimeType,
         ]);
     }
@@ -107,6 +115,8 @@ class UploadController extends Controller
     }
 }
 ```
+
+> **Legacy approach:** You can still use `$_FILES` directly for quick scripts. The PSR-7 `UploadedFileInterface` (`$request->getUploadedFiles()`) provides a testable, framework-agnostic alternative.
 
 ---
 
@@ -158,3 +168,4 @@ Add to `.gitignore` to avoid committing uploaded files:
 - Generating unpredictable filenames with `bin2hex(random_bytes())`
 - Serving files with correct Content-Type headers
 - Preventing path traversal with `basename()`
+- Using PSR-7 `UploadedFileInterface` via `ServerRequest::fromGlobals()`

--- a/wiki/app/tutorials/file-upload.md
+++ b/wiki/app/tutorials/file-upload.md
@@ -55,7 +55,7 @@ class UploadController extends Controller
             return;
         }
 
-        // Validate MIME — use finfo, not $_FILES['type'] (spoofable)
+        // Validate MIME - use finfo, not $_FILES['type'] (spoofable)
         $stream   = $uploaded->getStream();
         $tmpPath  = stream_get_meta_data($stream->detach())['uri'] ?? null;
 
@@ -96,7 +96,7 @@ class UploadController extends Controller
 
     public function serve(string $filename): void
     {
-        // Sanitise — no path traversal
+        // Sanitise - no path traversal
         $filename = basename($filename);
         $path     = self::UPLOAD_DIR . $filename;
 

--- a/wiki/app/tutorials/home.md
+++ b/wiki/app/tutorials/home.md
@@ -10,3 +10,8 @@ Hands-on guides for common SDF patterns.
 | [File Upload](file-upload.md) | Validate and store file uploads securely |
 | [Custom Middleware](custom-middleware.md) | Rate limiting, CORS, and logging middlewares |
 | [Docker & FrankenPHP](docker-frankenphp.md) | Production deployment with FrankenPHP + Docker |
+| [Env & Configuration](env.md) | Load environment variables from `.env` files with `\SDF\Env` |
+| [Encryption](encryption.md) | Encrypt and decrypt data using the `Encrypter` facade |
+| [CSRF Middleware](csrf-middleware.md) | Protect forms with the built-in CSRF middleware |
+| [CORS Middleware](cors-middleware.md) | Handle cross-origin requests with `CorsMiddleware` |
+| [Rate Limiting](rate-limiting.md) | Throttle requests using `RateLimitMiddleware` |

--- a/wiki/app/tutorials/home.md
+++ b/wiki/app/tutorials/home.md
@@ -9,3 +9,4 @@ Hands-on guides for common SDF patterns.
 | [Blog Application](blog.md) | Full MVC blog: routes, controller, Fuse templates, Spark queries |
 | [File Upload](file-upload.md) | Validate and store file uploads securely |
 | [Custom Middleware](custom-middleware.md) | Rate limiting, CORS, and logging middlewares |
+| [Docker & FrankenPHP](docker-frankenphp.md) | Production deployment with FrankenPHP + Docker |

--- a/wiki/app/tutorials/rest-api.md
+++ b/wiki/app/tutorials/rest-api.md
@@ -1,6 +1,6 @@
 # Tutorial: Building a REST API
 
-Build a fully working JSON REST API for a `products` resource using SDF routes, controllers, and Spark ORM.
+Build a fully working JSON REST API for a `products` resource using SDF routes, controllers, Spark ORM, and the Cache facade.
 
 ---
 
@@ -91,6 +91,7 @@ php sdf/cli g controller api/ProductController
 ```php
 <?php
 
+use SDF\Cache\Cache;
 use SDF\Controller;
 
 class ProductController extends Controller
@@ -98,19 +99,25 @@ class ProductController extends Controller
     /** GET /api/products */
     public function index(): void
     {
-        $products = Product::all();
+        $products = Cache::remember('api.products.all', 300, function () {
+            return Product::all();
+        });
         $this->response->json($products);
     }
 
     /** GET /api/products/{id} */
     public function show(int $id): void
     {
-        $rows = Product::query()->where('id', '=', $id)->get();
-        if (empty($rows)) {
+        $product = Cache::remember("api.products.$id", 300, function () use ($id) {
+            $rows = Product::query()->where('id', '=', $id)->get();
+            return $rows[0] ?? null;
+        });
+
+        if (!$product) {
             $this->response->status(404)->json(['error' => 'Product not found']);
             return;
         }
-        $this->response->json($rows[0]);
+        $this->response->json($product);
     }
 
     /** POST /api/products */
@@ -132,6 +139,7 @@ class ProductController extends Controller
             'stock' => (int) ($body['stock'] ?? 0),
         ]);
 
+        Cache::forget('api.products.all');
         $this->response->status(201)->json(['created' => true]);
     }
 
@@ -156,6 +164,8 @@ class ProductController extends Controller
             $id,
         ]);
 
+        Cache::forget('api.products.all');
+        Cache::forget("api.products.$id");
         $this->response->json(['updated' => true]);
     }
 
@@ -166,10 +176,16 @@ class ProductController extends Controller
         $stmt = $pdo->prepare('DELETE FROM products WHERE id = ?');
         $stmt->execute([$id]);
 
+        Cache::forget('api.products.all');
+        Cache::forget("api.products.$id");
         $this->response->status(204)->json([]);
     }
 }
 ```
+
+> **PSR-7 alternative:** Use `\SDF\Http\ServerRequest::fromGlobals()` to get a PSR-7 `ServerRequestInterface`
+> and access parsed JSON body via `$request->getParsedBody()`. The legacy
+> `$this->request->body()` remains fully supported for BC.
 
 ---
 
@@ -204,3 +220,4 @@ curl -X DELETE http://localhost:8080/api/products/1
 - Generating models, controllers, and migrations via CLI
 - Using `Spark::pdo()` for raw UPDATE/DELETE queries
 - Returning proper HTTP status codes with `$this->response->status()`
+- Caching GET responses with `Cache::remember()` and invalidating on mutation

--- a/wiki/app/tutorials/rest-api.md
+++ b/wiki/app/tutorials/rest-api.md
@@ -214,6 +214,25 @@ curl -X DELETE http://localhost:8080/api/products/1
 
 ---
 
+## New Feature Integration
+
+**CORS middleware** — Register `CorsMiddleware` on your API route group to allow cross-origin requests:
+```php
+Router::middleware(\SDF\Middleware\CorsMiddleware::class);
+```
+
+**Rate limiting** — Protect API endpoints from abuse with `RateLimitMiddleware`:
+```php
+Router::middleware(\SDF\Middleware\RateLimitMiddleware::class);
+```
+
+**Env-based config** — Store API keys in `.env` instead of hardcoding:
+```php
+$apiKey = \SDF\Env::get('API_KEY');
+```
+
+---
+
 ## What You Learned
 
 - Defining RESTful routes with HTTP method constraints

--- a/wiki/home.md
+++ b/wiki/home.md
@@ -26,10 +26,10 @@
   - [Cache](libraries/caching.md)
   - [Auth](libraries/auth.md)
   - [Session](libraries/session.md)
-   - [Flash Messages](libraries/flash.md)
-   - [HTTP (PSR-7)](libraries/http.md)
-   - [Swagger / OpenAPI](libraries/swagger.md)
-   - [Benchmark](libraries/benchmark.md)
+  - [Flash Messages](libraries/flash.md)
+  - [HTTP (PSR-7)](libraries/http.md)
+  - [Swagger / OpenAPI](libraries/swagger.md)
+  - [Benchmark](libraries/benchmark.md)
 
 ---
 

--- a/wiki/home.md
+++ b/wiki/home.md
@@ -26,8 +26,9 @@
   - [Cache](libraries/caching.md)
   - [Auth](libraries/auth.md)
   - [Session](libraries/session.md)
-  - [Flash Messages](libraries/flash.md)
-  - [Benchmark](libraries/benchmark.md)
+   - [Flash Messages](libraries/flash.md)
+   - [HTTP (PSR-7)](libraries/http.md)
+   - [Benchmark](libraries/benchmark.md)
 
 ---
 

--- a/wiki/home.md
+++ b/wiki/home.md
@@ -24,6 +24,7 @@
   - [Request](libraries/request.md)
   - [Response](libraries/response.md)
   - [Cache](libraries/caching.md)
+  - [Auth](libraries/auth.md)
   - [Session](libraries/session.md)
   - [Flash Messages](libraries/flash.md)
   - [Benchmark](libraries/benchmark.md)

--- a/wiki/home.md
+++ b/wiki/home.md
@@ -1,6 +1,6 @@
 # SDF Framework Documentation
 
-> **v2.0.0** — Fast · Secure · PHP-native
+> **v2.0.0** - Fast · Secure · PHP-native
 
 ## Navigation
 
@@ -18,7 +18,7 @@
   - [Core internals](sdf/core.md)
   - [CLI reference](sdf/cli.md)
 - **Libraries**
-  - [Fuse — View Engine](libraries/fuse.md)
+  - [Fuse - View Engine](libraries/fuse.md)
   - [Spark ORM](libraries/spark.md)
   - [Middleware & Guards](libraries/middleware.md)
   - [Request](libraries/request.md)
@@ -28,6 +28,7 @@
   - [Session](libraries/session.md)
    - [Flash Messages](libraries/flash.md)
    - [HTTP (PSR-7)](libraries/http.md)
+   - [Swagger / OpenAPI](libraries/swagger.md)
    - [Benchmark](libraries/benchmark.md)
 
 ---
@@ -66,7 +67,7 @@ project-sdf/
 └── index.php           # Application entrypoint
 ```
 
-### Quick Start — Hello World
+### Quick Start - Hello World
 
 **1. Create a route** in `app/config/routes.php`:
 

--- a/wiki/home.md
+++ b/wiki/home.md
@@ -30,6 +30,10 @@
   - [HTTP (PSR-7)](libraries/http.md)
   - [Swagger / OpenAPI](libraries/swagger.md)
   - [Benchmark](libraries/benchmark.md)
+- **Agentic Workflow**
+  - [Introduction](agentic_workflow/introduction.md)
+  - [Setup Guide](agentic_workflow/tutorials/setup.md)
+  - [Project SDF Skill](agentic_workflow/skills/project-sdf.md)
 
 ---
 

--- a/wiki/home.md
+++ b/wiki/home.md
@@ -24,6 +24,8 @@
   - [Request](libraries/request.md)
   - [Response](libraries/response.md)
   - [Cache](libraries/caching.md)
+  - [Session](libraries/session.md)
+  - [Flash Messages](libraries/flash.md)
   - [Benchmark](libraries/benchmark.md)
 
 ---

--- a/wiki/libraries/auth.md
+++ b/wiki/libraries/auth.md
@@ -44,7 +44,7 @@ $config['auth'] = [
 | Option | Default | Description |
 |---|---|---|
 | `default` | `session` | Active guard (`session` or `jwt`) |
-| `guards.jwt.secret` | — | HMAC-SHA256 secret key for signing JWTs |
+| `guards.jwt.secret` | - | HMAC-SHA256 secret key for signing JWTs |
 | `guards.jwt.ttl` | `3600` | Access token lifetime in seconds |
 | `guards.jwt.refresh_ttl` | `604800` | Refresh token lifetime in seconds (7 days) |
 | `providers.*.model` | `\App\Models\User::class` | User model class with static `find()` and `where()` |
@@ -168,7 +168,7 @@ Rejects unauthenticated requests with a `401` HTTP status.
 Router::middleware(\SDF\Auth\AuthMiddleware::class);
 ```
 
-All routes registered after this middleware require authentication. To protect only specific routes, register the middleware in a route group or use per-route middleware arrays (not yet supported by the Router — subclass or customise as needed).
+All routes registered after this middleware require authentication. To protect only specific routes, register the middleware in a route group or use per-route middleware arrays (not yet supported by the Router - subclass or customise as needed).
 
 ## Testing
 

--- a/wiki/libraries/auth.md
+++ b/wiki/libraries/auth.md
@@ -76,7 +76,6 @@ class User extends Model
 
 ```php
 use SDF\Auth\Auth;
-use SDF\Auth\Auth;
 
 // Check authentication
 if (Auth::check()) {

--- a/wiki/libraries/auth.md
+++ b/wiki/libraries/auth.md
@@ -1,0 +1,198 @@
+# SDF Auth
+
+## Overview
+
+The `Auth` system provides first-class authentication with two built-in guards:
+
+| Guard | Namespace | Use Case |
+|---|---|---|
+| **SessionGuard** | `SDF\Auth\SessionGuard` | Classic PHP session auth (web apps) |
+| **JwtGuard** | `SDF\Auth\JwtGuard` | Stateless JWT via `Authorization: Bearer` (APIs) |
+
+A unified facade (`SDF\Auth\Auth`) delegates to the active guard so your code stays the same regardless of which guard is configured.
+
+## Configuration
+
+Create `app/config/auth.php`:
+
+```php
+<?php
+
+$config['auth'] = [
+    'default' => 'session',
+    'guards' => [
+        'session' => [
+            'provider' => 'users',
+        ],
+        'jwt' => [
+            'provider' => 'users',
+            'secret' => 'your-256-bit-secret',
+            'ttl' => 3600,
+            'refresh_ttl' => 604800,
+        ],
+    ],
+    'providers' => [
+        'users' => [
+            'model' => \App\Models\User::class,
+        ],
+    ],
+];
+```
+
+### Options
+
+| Option | Default | Description |
+|---|---|---|
+| `default` | `session` | Active guard (`session` or `jwt`) |
+| `guards.jwt.secret` | — | HMAC-SHA256 secret key for signing JWTs |
+| `guards.jwt.ttl` | `3600` | Access token lifetime in seconds |
+| `guards.jwt.refresh_ttl` | `604800` | Refresh token lifetime in seconds (7 days) |
+| `providers.*.model` | `\App\Models\User::class` | User model class with static `find()` and `where()` |
+
+## User Model
+
+The user model must expose:
+- A public `$id` property (primary key)
+- A public `$password` property (bcrypt hash)
+- Static `find($id): ?object`
+- Static `where(string $column, mixed $value): object` returning a query builder with `->first(): ?object`
+
+If you use Spark ORM, your model already satisfies this contract:
+
+```php
+<?php
+
+namespace App\Models;
+
+use SDF\Spark\Model;
+
+class User extends Model
+{
+    protected static string $table = 'users';
+}
+```
+
+## Facade Usage
+
+```php
+use SDF\Auth\Auth;
+use SDF\Auth\Auth;
+
+// Check authentication
+if (Auth::check()) {
+    echo 'Logged in';
+}
+
+// Get authenticated user
+$user = Auth::user();
+
+// Login
+$user = User::find(1);
+Auth::login($user);
+
+// Attempt with credentials
+if (Auth::attempt(['email' => $email, 'password' => $password])) {
+    // authenticated
+}
+
+// Logout
+Auth::logout();
+
+// Switch guard
+Auth::guard('jwt')->check();
+```
+
+## Session Guard
+
+Stores the user ID in `$_SESSION['_auth_id']` and hydrates the full model on each request.
+
+```php
+use SDF\Auth\SessionGuard;
+use SDF\Auth\UserProvider;
+
+$provider = new UserProvider(\App\Models\User::class);
+$guard = new SessionGuard($provider);
+
+$guard->login($user);
+$guard->check();    // true
+$guard->user();     // User model
+$guard->logout();
+```
+
+## JWT Guard
+
+Reads the `Authorization: Bearer <token>` header, decodes and verifies the JWT, and hydrates the user.
+
+```php
+use SDF\Auth\JwtGuard;
+use SDF\Auth\UserProvider;
+use SDF\Request;
+
+$provider = new UserProvider(\App\Models\User::class);
+$guard = new JwtGuard($provider, new Request(), 'your-secret');
+
+$user = \App\Models\User::find(1);
+$token = $guard->issueToken($user);
+
+// Guard reads bearer token automatically
+$guard->check(); // true
+```
+
+### Token Refresh
+
+```php
+// Issue a refresh token alongside the access token
+$accessToken  = $guard->issueToken($user);
+$refreshToken = $guard->issueRefreshToken($user);
+
+// Later, when the access token expires:
+$result = $guard->refresh($refreshToken);
+// Returns: ['access_token' => '...', 'refresh_token' => '...', 'token_type' => 'Bearer', 'expires_in' => 3600]
+
+// Or via the facade:
+$result = Auth::refresh($refreshToken);
+```
+
+### Via Facade
+
+```php
+Auth::guard('jwt')->issueToken($user);
+Auth::guard('jwt')->refresh($refreshToken);
+```
+
+## AuthMiddleware
+
+Rejects unauthenticated requests with a `401` HTTP status.
+
+```php
+Router::middleware(\SDF\Auth\AuthMiddleware::class);
+```
+
+All routes registered after this middleware require authentication. To protect only specific routes, register the middleware in a route group or use per-route middleware arrays (not yet supported by the Router — subclass or customise as needed).
+
+## Testing
+
+The `Auth` facade provides `setGuard()` and `reset()` for swapping guards in tests:
+
+```php
+use SDF\Auth\Auth;
+use PHPUnit\Framework\TestCase;
+
+class MyTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        Auth::reset();
+    }
+
+    public function test_something(): void
+    {
+        // Swap in a mock guard
+        $mock = $this->createMock(\SDF\Auth\Guard::class);
+        $mock->method('check')->willReturn(true);
+        Auth::setGuard('session', $mock);
+
+        $this->assertTrue(Auth::check());
+    }
+}
+```

--- a/wiki/libraries/caching.md
+++ b/wiki/libraries/caching.md
@@ -88,7 +88,7 @@ Cache::set('bio', 'degraded', new DateInterval('PT1H')); // 1 hour
 
 ### Graceful fallback
 
-Redis and Memcached drivers degrade gracefully when their extensions are missing or the server is unreachable — they return defaults and return `false` for writes. No exceptions are thrown.
+Redis and Memcached drivers degrade gracefully when their extensions are missing or the server is unreachable - they return defaults and return `false` for writes. No exceptions are thrown.
 
 ```php
 $driver = new RedisDriver(['host' => 'unreachable']);

--- a/wiki/libraries/flash.md
+++ b/wiki/libraries/flash.md
@@ -1,0 +1,130 @@
+# SDF Flash Messages
+
+## Overview
+
+The `Flash` class provides one-time notification messages stored in the session. A flash message set in one request is available in the next and automatically consumed when retrieved. This is useful for redirect-based workflows (e.g., "Record saved" after a POST).
+
+## How It Works
+
+Flash messages use a two-bucket aging system:
+
+| Bucket | Purpose |
+|---|---|
+| `_sdf_flash_new` | Messages set during the current request, intended for the **next** request |
+| `_sdf_flash_cur` | Messages promoted from `_new` — available to **this** request |
+
+On each `Flash` construction the aging cycle runs:
+1. `_cur` is discarded (was for the previous request).
+2. `_new` is promoted to `_cur` (now readable via `get()`).
+
+## Class: `SDF\Flash`
+
+### Constructor
+
+```php
+$flash = new SDF\Flash(?SDF\Session $session = null);
+```
+
+If no session is provided the global `Session` singleton is used.
+
+### Methods
+
+#### `set(string $key, mixed $value): self`
+
+Store a flash message for the **next** request.
+
+```php
+// In a POST handler before redirect
+$flash->set('success', 'User created successfully.');
+$flash->set('errors', ['name' => 'Required']);
+```
+
+#### `get(string $key, mixed $default = null): mixed`
+
+Retrieve a flash message. The message is **consumed** (removed from the session).
+
+```php
+// On the page after redirect
+$message = $flash->get('success'); // 'User created successfully.'
+$message = $flash->get('success'); // null (consumed)
+```
+
+#### `has(string $key): bool`
+
+Check if a flash message exists without consuming it.
+
+```php
+if ($flash->has('errors')) {
+    // show error block
+}
+```
+
+#### `all(): array`
+
+Return all flash messages without consuming them.
+
+```php
+$messages = $flash->all();
+```
+
+#### `keep(string $key): self`
+
+Keep a flash message for one more request (prevents consumption during aging).
+
+```php
+$flash->keep('warning'); // survives another redirect
+```
+
+#### `now(string $key, mixed $value): self`
+
+Set a flash message that is available **immediately** in the current request. It will not persist to the next request.
+
+```php
+$flash->now('info', 'This is shown right now.');
+echo $flash->get('info'); // 'This is shown right now.'
+```
+
+#### `flash(string $key, mixed $value): self`
+
+Alias of `set()`. Included for familiarity with other frameworks.
+
+```php
+$flash->flash('notice', 'Account updated.');
+```
+
+### In Controllers
+
+```php
+class UserController extends SDF\Controller
+{
+    public function store()
+    {
+        // ... validate and save ...
+
+        $flash = new SDF\Flash();
+        $flash->set('success', 'User saved.');
+        $this->response->redirect('/users');
+    }
+
+    public function index()
+    {
+        $flash = new SDF\Flash();
+        $data['message'] = $flash->get('success');
+        $this->load->view('users/index', $data);
+    }
+}
+```
+
+## Testing
+
+Flash messages rely on `$_SESSION`. In PHPUnit tests, start a session in `setUp`:
+
+```php
+protected function setUp(): void
+{
+    if (session_status() === PHP_SESSION_NONE) {
+        session_start();
+    }
+    $_SESSION = [];
+}
+```

--- a/wiki/libraries/flash.md
+++ b/wiki/libraries/flash.md
@@ -11,7 +11,7 @@ Flash messages use a two-bucket aging system:
 | Bucket | Purpose |
 |---|---|
 | `_sdf_flash_new` | Messages set during the current request, intended for the **next** request |
-| `_sdf_flash_cur` | Messages promoted from `_new` — available to **this** request |
+| `_sdf_flash_cur` | Messages promoted from `_new` - available to **this** request |
 
 On each `Flash` construction the aging cycle runs:
 1. `_cur` is discarded (was for the previous request).

--- a/wiki/libraries/fuse.md
+++ b/wiki/libraries/fuse.md
@@ -1,6 +1,6 @@
 # Fuse View Engine
 
-Fuse is the SDF template engine. **v2.0.0 removes `eval()`** — templates compile to PHP files cached on disk. Secure, fast, zero-overhead after first render.
+Fuse is the SDF template engine. **v2.0.0 removes `eval()`** - templates compile to PHP files cached on disk. Secure, fast, zero-overhead after first render.
 
 ## Rendering a View
 
@@ -33,7 +33,7 @@ In the view, data is available as extracted PHP variables:
 
 ## Variable Interpolation
 
-`{{ $var }}` — escaped via `htmlspecialchars`. Safe by default.
+`{{ $var }}` - escaped via `htmlspecialchars`. Safe by default.
 
 ```html
 <p>Welcome, {{ $user['name'] }}!</p>
@@ -85,7 +85,7 @@ In the view, data is available as extracted PHP variables:
 @endWhile
 ```
 
-### `@var` — Inline PHP assignment
+### `@var` - Inline PHP assignment
 
 ```html
 @var $greeting = 'Hello, ' . $user['name'] . '!';
@@ -131,7 +131,7 @@ In the view, data is available as extracted PHP variables:
 ## Cache Behaviour (v2.0.0)
 
 - First render: template compiled → written to `SDF_APP_CACHE/views/` (or `/tmp/fuse_cache/`)
-- Subsequent renders: compiled file used directly — no parsing overhead
+- Subsequent renders: compiled file used directly - no parsing overhead
 - Cache invalidated automatically when source file `mtime` changes
 
 ## Supported Extensions

--- a/wiki/libraries/http.md
+++ b/wiki/libraries/http.md
@@ -4,7 +4,7 @@ SDF provides a **PSR-7** (`psr/http-message` ^2.0) implementation for HTTP messa
 
 ## Installation
 
-Already included — `psr/http-message` is installed via Composer in `composer.json`.
+Already included - `psr/http-message` is installed via Composer in `composer.json`.
 
 ## Classes
 

--- a/wiki/libraries/http.md
+++ b/wiki/libraries/http.md
@@ -1,0 +1,106 @@
+# HTTP Messages (PSR-7)
+
+SDF provides a **PSR-7** (`psr/http-message` ^2.0) implementation for HTTP messages, alongside the legacy mutable `SDF\Request` / `SDF\Response` classes.
+
+## Installation
+
+Already included — `psr/http-message` is installed via Composer in `composer.json`.
+
+## Classes
+
+All classes live in `SDF\Http\`:
+
+| Class | Implements | Description |
+|---|---|---|
+| `Stream` | `StreamInterface` | Wraps a string or resource handle |
+| `Uri` | `UriInterface` | Parses/constructs URIs; immutable `with*` |
+| `UploadedFile` | `UploadedFileInterface` | Represents an uploaded file |
+| `Response` | `ResponseInterface` | Immutable HTTP response |
+| `ServerRequest` | `ServerRequestInterface` | Immutable server request; includes `fromGlobals()` factory |
+
+## Usage
+
+### Creating a ServerRequest from globals
+
+```php
+$request = \SDF\Http\ServerRequest::fromGlobals();
+
+$method = $request->getMethod();          // "GET", "POST", etc.
+$uri    = $request->getUri();             // UriInterface
+$params = $request->getQueryParams();     // $_GET
+$body   = $request->getParsedBody();      // parsed JSON or $_POST
+$files  = $request->getUploadedFiles();   // UploadedFileInterface[]
+$attrs  = $request->getAttributes();      // custom attributes
+```
+
+### Creating a PSR-7 response
+
+```php
+$response = new \SDF\Http\Response(
+    200,                                  // status code
+    ['Content-Type' => 'application/json'],
+    new \SDF\Http\Stream(json_encode(['ok' => true])),
+    '1.1',
+);
+```
+
+### Immutable operations
+
+All `with*` methods return a **new instance**:
+
+```php
+$req  = new \SDF\Http\ServerRequest('GET', '/');
+$req2 = $req->withMethod('POST')
+            ->withHeader('X-Custom', 'value')
+            ->withAttribute('role', 'admin');
+
+$req->getMethod();   // "GET" (unchanged)
+$req2->getMethod();  // "POST"
+```
+
+### Attribute routing
+
+Attributes are useful for carrying route-matched data:
+
+```php
+$request = $request
+    ->withAttribute('route', 'user.show')
+    ->withAttribute('params', ['id' => 5]);
+
+$route = $request->getAttribute('route');
+$id    = $request->getAttribute('params')['id'] ?? null;
+```
+
+### Working with uploaded files
+
+```php
+$files = $request->getUploadedFiles();
+$avatar = $files['avatar'] ?? null;
+
+if ($avatar && $avatar->getError() === UPLOAD_ERR_OK) {
+    $stream = $avatar->getStream();
+    // or
+    $avatar->moveTo('/path/to/uploads/' . $avatar->getClientFilename());
+}
+```
+
+## Legacy Bridge
+
+The legacy `SDF\Request` and `SDF\Response` classes have `toPsr()` / `fromPsr()` methods:
+
+```php
+// Legacy → PSR-7
+$psrRequest  = $request->toPsr();          // SDF\Request → ServerRequestInterface
+$psrResponse = $response->toPsr();         // SDF\Response → ResponseInterface
+
+// PSR-7 → Legacy
+$legacyRequest  = \SDF\Request::fromPsr($psrRequest);
+$legacyResponse = \SDF\Response::fromPsr($psrResponse);
+```
+
+> **Note:** `fromPsr` mutates PHP superglobals (`$_GET`, `$_POST`, `$_COOKIE`, `$_SERVER`) to match the PSR-7 request state.
+
+## Requirements
+
+- PHP 8.2+
+- `psr/http-message` ^2.0 (Composer)

--- a/wiki/libraries/logger.md
+++ b/wiki/libraries/logger.md
@@ -56,7 +56,7 @@ Handlers implement a minimal interface (handle(LogRecord), flush()). You may imp
 
 Design notes
 
-- Messages may be strings or callables — callables are lazily evaluated for performance.
+- Messages may be strings or callables - callables are lazily evaluated for performance.
 - Marker is an optional short tag useful for filtering and quick classification.
 - ConsoleHandler produces colored output by default when TTY available. In daemonized environments you may prefer file handlers.
 

--- a/wiki/libraries/middleware.md
+++ b/wiki/libraries/middleware.md
@@ -89,35 +89,33 @@ class AdminPanel extends SDF\Controller
 }
 ```
 
-## Real-World Auth Middleware
+## AuthMiddleware (built-in)
+
+The framework ships with `SDF\Auth\AuthMiddleware`. It rejects unauthenticated requests with a 401 status:
+
+```php
+Router::middleware(\SDF\Auth\AuthMiddleware::class);
+```
+
+To use the JWT guard instead of sessions, subclass:
 
 ```php
 <?php
 
 namespace App\Middleware;
 
-use SDF\Middleware;
-use SDF\Request;
+use SDF\Auth\AuthMiddleware;
 
-class AuthMiddleware implements Middleware
+class ApiAuthMiddleware extends AuthMiddleware
 {
-    public function handle(Request $request, \Closure $next): mixed
+    public function __construct()
     {
-        $token = $request->header('Authorization');
-        if (!$token || !str_starts_with($token, 'Bearer ')) {
-            http_response_code(401);
-            echo json_encode(['error' => 'Unauthorized']);
-            return null;
-        }
-
-        $jwt = substr($token, 7);
-        // TODO: validate JWT via SDF-9 Auth layer
-        $request->set('user_jwt', $jwt);
-
-        return $next($request);
+        parent::__construct('jwt');
     }
 }
 ```
+
+See the [Auth documentation](auth.md) for full usage.
 
 ## Rate Limit Middleware Example
 

--- a/wiki/libraries/session.md
+++ b/wiki/libraries/session.md
@@ -94,8 +94,8 @@ $session->destroy();
 new SDF\Session(?string $cacheExpire = null, ?string $cacheLimiter = null);
 ```
 
-- `$cacheExpire` — Session cache expiration in minutes (sets `session_cache_expire()`).
-- `$cacheLimiter` — Session cache limiter header value (sets `session_cache_limiter()`).
+- `$cacheExpire` - Session cache expiration in minutes (sets `session_cache_expire()`).
+- `$cacheLimiter` - Session cache limiter header value (sets `session_cache_limiter()`).
 
 ### In Controllers
 

--- a/wiki/libraries/session.md
+++ b/wiki/libraries/session.md
@@ -1,0 +1,112 @@
+# SDF Session
+
+## Overview
+
+The `Session` class provides a fluent interface over PHP's native session handling. It is a PSR-4 core class in the `SDF` namespace and is auto-started in `sdf/__init.php` so a session is always available.
+
+## Class: `SDF\Session`
+
+### Singleton Access
+
+```php
+$session = SDF\Session::getInstance();
+```
+
+The singleton is automatically created during framework bootstrap. Controllers may also construct a fresh instance:
+
+```php
+$session = new SDF\Session();
+```
+
+### Methods
+
+#### `set(string $key, mixed $value): self`
+
+Store a value in the session.
+
+```php
+$session->set('user_id', 42);
+$session->set('cart', ['item' => 1, 'qty' => 3]);
+```
+
+#### `get(string $key, mixed $default = null): mixed`
+
+Retrieve a value from the session.
+
+```php
+$userId = $session->get('user_id');
+$name   = $session->get('name', 'Guest');
+```
+
+#### `has(string $key): bool`
+
+Check if a key exists in the session.
+
+```php
+if ($session->has('user_id')) {
+    // user is logged in
+}
+```
+
+#### `remove(string $key): void`
+
+Remove a single key from the session.
+
+```php
+$session->remove('temp_data');
+```
+
+#### `clear(): void`
+
+Remove all session data.
+
+```php
+$session->clear();
+```
+
+#### `id(): string|false`
+
+Return the current session ID.
+
+```php
+$id = $session->id();
+```
+
+#### `regenerate(bool $deleteOld = false): self`
+
+Regenerate the session ID (recommended after login for session fixation protection).
+
+```php
+$session->regenerate(true);
+```
+
+#### `destroy(): void`
+
+Destroy the session and all its data.
+
+```php
+$session->destroy();
+```
+
+### Constructor Parameters
+
+```php
+new SDF\Session(?string $cacheExpire = null, ?string $cacheLimiter = null);
+```
+
+- `$cacheExpire` — Session cache expiration in minutes (sets `session_cache_expire()`).
+- `$cacheLimiter` — Session cache limiter header value (sets `session_cache_limiter()`).
+
+### In Controllers
+
+```php
+class HomeController extends SDF\Controller
+{
+    public function index()
+    {
+        $session = SDF\Session::getInstance();
+        $session->set('visited', true);
+        // ...
+    }
+}
+```

--- a/wiki/libraries/spark.md
+++ b/wiki/libraries/spark.md
@@ -4,11 +4,31 @@ Spark is the SDF v2.0.0 database layer. It provides a clean PDO-backed QueryBuil
 
 ## Connecting
 
-Call `Spark::connect()` once — typically in `index.php` or a bootstrap config:
+Spark auto-connects from `app/config/database.php` on the first query — no manual `connect()` call needed:
 
 ```php
+// app/config/database.php
 <?php
+$config['database'] = [
+    'driver'   => 'sqlite',      // mysql | pgsql | sqlite | sqlsrv | manual
+    'host'     => '127.0.0.1',
+    'name'     => 'myapp',
+    'user'     => 'dbuser',
+    'password' => 'secret',
+    'port'     => 3306,
+    'charset'  => 'utf8mb4',
+    // For sqlite use either a path or :memory:
+    'path'     => ':memory:',
+];
+```
 
+The PDO connection is created lazily when `Spark::pdo()`, `Spark::table()`, or any query runs. Pages that never hit the database pay zero connection overhead.
+
+### Manual connect (advanced)
+
+For runtime DSN overrides or multiple connections:
+
+```php
 use SDF\Spark;
 
 Spark::connect(
@@ -17,35 +37,13 @@ Spark::connect(
     password: 'secret',
     options:  [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
 );
-```
 
-For SQLite:
-
-```php
-Spark::connect('sqlite:' . SDF_ROOT . '/database.sqlite');
+Spark::connect('sqlite:/var/www/db.sqlite');
 ```
 
 Configuration and DSN notes
 
-- Recommended database config file shape (top-level keys):
-
-```php
-// app/config/database.php
-<?php
-$config = [
-  'driver'  => 'sqlite',      // mysql | pgsql | sqlite | sqlsrv | manual
-  'host'    => '127.0.0.1',
-  'name'    => 'myapp',
-  'user'    => 'dbuser',
-  'password'=> 'secret',
-  'port'    => 3306,
-  'charset' => 'utf8mb4',
-  // For sqlite use either a path or :memory:
-  'path'    => ':memory:'
-];
-```
-
-- The initializer accepts either a full DSN (e.g. `sqlite::memory:` or `mysql:...`) provided via `dsn`, or a `path`/`host`+`name` combination. When using SQLite, pass a filesystem path (e.g. `/var/www/db.sqlite`) or `:memory:`. The bootstrap will detect an already-formed DSN and avoid double-prefixing `sqlite:`.
+- The config accepts either a full DSN via `dsn`, or a `path`/`host`+`name` combination. SQLite paths are auto-prefixed with `sqlite:` unless they already contain a colon (e.g. `sqlite::memory:`).
 
 - `Spark::connect()` accepts nullable username/password to accommodate drivers (e.g., Windows-auth SQL Server or DSN-only connections).
 
@@ -65,7 +63,7 @@ use SDF\Spark\Model;
 
 class User extends Model
 {
-    protected static string $table = 'users'; // optional — defaults to 'users'
+    protected static string $table = 'users'; // optional - defaults to 'users'
 }
 ```
 
@@ -121,7 +119,7 @@ $stmt->execute(['pending']);
 $count = $stmt->fetchColumn();
 ```
 
-## Real-World Example — Blog Controller
+## Real-World Example - Blog Controller
 
 ```php
 <?php

--- a/wiki/libraries/swagger.md
+++ b/wiki/libraries/swagger.md
@@ -1,0 +1,106 @@
+# OpenAPI / Swagger Documentation
+
+SDF integrates with **zircote/swagger-php** to generate OpenAPI 3.x specs from PHP 8 attributes, and serves Swagger UI for interactive documentation.
+
+---
+
+## Annotating Controllers
+
+Use `#[OA\...]` attributes on your controller methods:
+
+```php
+<?php
+
+use OpenApi\Attributes as OA;
+
+#[OA\Info(version: "1.0.0", title: "Products API")]
+class ProductController extends SDF\Controller
+{
+    #[OA\Get(
+        path: "/api/products",
+        summary: "List all products",
+        tags: ["Products"],
+        responses: [
+            new OA\Response(response: 200, description: "Product list"),
+        ],
+    )]
+    public function index(): void
+    {
+        $this->response->json(Product::all());
+    }
+
+    #[OA\Post(
+        path: "/api/products",
+        summary: "Create a product",
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                properties: [
+                    new OA\Property(property: "name", type: "string"),
+                    new OA\Property(property: "price", type: "number"),
+                ],
+            ),
+        ),
+        tags: ["Products"],
+        responses: [
+            new OA\Response(response: 201, description: "Created"),
+            new OA\Response(response: 422, description: "Validation error"),
+        ],
+    )]
+    public function store(): void
+    {
+        // ...
+    }
+}
+```
+
+## Endpoints
+
+| Route | Description |
+|---|---|
+| `GET /api/openapi.json` | OpenAPI 3.x spec (JSON) |
+| `GET /api/docs` | Swagger UI (CDN) |
+
+> These routes are automatically registered in `development` environment when `\SDF\Swagger\SwaggerController` is available.
+
+## CLI Command
+
+Generate the spec offline:
+
+```bash
+php sdf/cli swagger generate
+# Writes openapi.json to the current directory
+
+php sdf/cli swagger generate path/to/openapi.json
+# Custom output path
+```
+
+## Generator API
+
+```php
+use SDF\Swagger\SwaggerGenerator;
+
+$generator = new SwaggerGenerator(
+    title: 'My API',
+    apiVersion: '2.0.0',
+    serverUrl: 'https://api.example.com',
+    description: 'Optional description',
+);
+
+// As JSON string
+$json = $generator->generate();
+
+// As array
+$array = $generator->generateArray();
+
+// Add extra scan paths
+$generator->addPaths('/path/to/models', '/path/to/libs');
+
+// Override OpenAPI version
+$generator->setSpecVersion('3.1.0');
+```
+
+## Requirements
+
+- `zircote/swagger-php: ^4.0` (in `require-dev`)
+- PHP 8.1+ (for attributes)

--- a/wiki/sdf/cli.md
+++ b/wiki/sdf/cli.md
@@ -131,7 +131,8 @@ The generated file will be `tests/UserTest.php` or `tests/UserControllerTest.php
 ## Serve
 
 The serve command allows you to run the application in development mode. The application is run on `localhost:8000` by
-default.
+default. It auto-detects a `frankenphp` binary — if found it uses `frankenphp php-server`, otherwise falls back to the
+PHP built-in server (`php -S`).
 
 ```bash
 ./sdf/cli serve

--- a/wiki/sdf/core.md
+++ b/wiki/sdf/core.md
@@ -21,7 +21,7 @@ index.php
 Scans `app/config/` for `.php` and `.json` files. Merges into `Core::$config`. Result cached to `/tmp/sdf_config.cache`.
 
 ```php
-// Internal usage — called automatically at boot.
+// Internal usage - called automatically at boot.
 // Access config in controllers:
 $mailHost = $this->getConfig('mail', 'host');
 ```


### PR DESCRIPTION
### Summary

Adds several new core libraries and middleware for the SDF framework:

- **Env** — dotenv parser with quotes, inline comments, `${VAR}` placeholders; loaded in bootstrap before config
- **Encryption** — AES-256-CBC encrypt/decrypt via `Encrypter` with `fromConfig()` factory
- **CSRF Middleware** — per-session token validation (419 on mismatch)
- **CORS Middleware** — configurable origins/methods/headers, OPTIONS preflight → 204
- **Rate Limit Middleware** — per-IP+route via Cache, configurable window, 429 with Retry-After
- **Global helpers** — `env()`, `csrf_token()`, `csrf_field()`
- **Tests** — 35 new tests (207 total, 412 assertions, all passing)
- **Wiki** — tutorials updated to reference new features

### Changes

| Category | Files |
|---|---|
| Core | `sdf/core/Env.php`, `sdf/core/helpers.php`, `sdf/core/Encryption/Encrypter.php` |
| Middleware | `sdf/core/Middleware/CsrfMiddleware.php`, `sdf/core/Middleware/CorsMiddleware.php`, `sdf/core/Middleware/RateLimitMiddleware.php` |
| Config | `app/config/encryption.php`, `app/config/cors.php`, `.env.example` |
| Tests | `EnvTest`, `EncryptionTest`, `CsrfTest`, `CorsTest`, `RateLimitTest` |
| Bootstrap | `sdf/__init.php`, `tests/bootstrap.php` |
| Wiki | 5 tutorial files updated |